### PR TITLE
Fix Windows build instructions

### DIFF
--- a/en/contributing/build.md
+++ b/en/contributing/build.md
@@ -23,7 +23,7 @@ To build the *DroneCore* C++ Library on Linux (or Mac OS X after installing the 
 1. First install the dependencies
    ```bash
    sudo apt-get update -y
-   sudo apt-get install cmake build-essential colordiff astyle git libcurl4-openssl-dev -y
+   sudo apt-get install cmake build-essential colordiff astyle git libcurl4-openssl-dev doxygen -y
    ```
    > **Note** If the build reports a missing dependency, confirm that the set above matches the requirements in the [Dockerfile](https://github.com/dronecore/DroneCore/blob/master/Dockerfile).
 
@@ -36,6 +36,18 @@ To build the *DroneCore* C++ Library on Linux (or Mac OS X after installing the 
 1. Build the C++ library by calling:
    ```
    make default
+   ```
+   
+1. (Optionally) Install the binaries and header files in the default location:
+   > **Tip** This is needed to build DroneCore applications (but not for the unit and integration tests).
+   
+   ```
+   make default install
+   ```
+   
+1. (Optionally) Build the API Reference documentation by calling:
+   ```
+   make docs
    ```
 
 ### Windows
@@ -63,6 +75,13 @@ To build the *DroneCore* C++ Library on Windows:
    mkdir build && cd build
    cmake -DWIN_CURL_INCLUDE_DIR:STRING=C:\\curl-7.54.1\\include -DWIN_CURL_LIB:STRING="C:\curl-7.54.1\builds\libcurl-vc14-x64-release-static-ipv6-sspi-winssl\lib\libcurl_a.lib" -G "Visual Studio 14 2015 Win64" ..
    cmake --build .
+   ```
+   
+1. (Optionally) Install the binaries and header files in the default location:
+   > **Tip** This is needed to build DroneCore applications (but not for the unit and integration tests).
+   
+   ```
+   cmake --build . --target install
    ```
 
 ### Using the Compiled C++ Library

--- a/en/examples/takeoff_and_land.md
+++ b/en/examples/takeoff_and_land.md
@@ -2,21 +2,20 @@
 
 This example shows how to use basic DroneCore features. 
 
-It sets up a UDP connection, waits for a device to appear, and commands it to takeoff and then land again. While flying the vehicle receives telemetry. The example is implemented in C++ and <????>.
+It sets up a UDP connection, waits for a device to appear, and commands it to takeoff and then land again. While flying the vehicle receives telemetry. The example is implemented in C++ (only).
 
 
 <!-- [Gitbook-api-theme](https://github.com/GitbookIO/theme-api#gitbook-api-theme) shows how the methods work -->
 
 > **Tip** The full source code for the example [can be found here](https://github.com/dronecore/DroneCore/tree/master/example/takeoff_land).
 
-{% method %}
 ## Build Example {#build_example}
 
 To build and try it, start PX4 in SITL and build and run the example as follows:
 
-
-{% sample lang="cpp" %}
-Build and install the DroneCore library first:
+### Linux
+First [Build and install the DroneCore C++ Library](../contributing/build.md).
+Make sure that you install the library and headers in the standard location:
 
 ```
 make default install
@@ -33,17 +32,30 @@ make && ./takeoff_and_land
 
 Note that the example needs to be linked to a thread library (see [CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/master/example/takeoff_land/CMakeLists.txt))
 
-{% sample lang="python" %}
-PYTHON EXAMPLE NOT ADDED YET
-{% endmethod %}
+### Windows
+
+First [Build and install the DroneCore C++ Library](../contributing/build.md).
+Make sure that you install the library and headers in the standard location:
+
+```
+cmake --build . --target install
+```
+
+Build the example using:
+```
+cd example/takeoff_land/
+mkdir build && cd build
+cmake --build .
+```
+
+The debug binary for the example is stored under \Debug folder.
 
 
-{% method %}
 ## Source code {#source_code}
 
 The full source code for the example [can be found here](https://github.com/dronecore/DroneCore/blob/master/example/).
 
-{% sample lang="cpp" %}
+
 [CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/master/example/takeoff_land/CMakeLists.txt)
 
 ```make
@@ -169,9 +181,3 @@ int main(int /*argc*/, char ** /*argv*/)
     return 0;
 }
 ```
-
-{% sample lang="python" %}
-PYTHON EXAMPLE NOT ADDED YET
-{% endmethod %}
-
-


### PR DESCRIPTION
This updates the build instructions for windows in line with: https://github.com/dronecore/DroneCore/pull/51/

It also removes the "Python" ish instructions - since it is not clear when those examples will appear.