### PR TITLE
Create guide section and add general paradigms topic

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -3,6 +3,8 @@
 * [Introduction](README.md)
   * [FAQ](getting_started/faq.md)
 * [Quick Start](getting_started/README.md)
+* [Guide](guide/README.md)
+  * [Usage/Paradigms](guide/general_usage.md)
 * [Example](examples/README.md)
   * [Takeoff and Land](examples/takeoff_and_land.md)
 * [API Reference](api_reference/README.md)

--- a/en/guide/README.md
+++ b/en/guide/README.md
@@ -1,18 +1,4 @@
 # API Guide
 
-This topic provides a broad overview of how to use the Dronecore library.
-
-## API overview
-
-<!-- all these links should go to API ref, once created -->
-
-- [dronecore](https://github.com/dronecore/DroneCore/blob/master/include/dronecore.h) (include/dronecore.h): set up connection, discover devices
-- [device](https://github.com/dronecore/DroneCore/blob/master/include/device.h) (include/device.h): a device providing access to modules below using ...
-- [device_plugin_container.h.in](https://github.com/dronecore/DroneCore/blob/master/include/device_plugin_container.h.in) (include/device_plugin_container.h.in) which is auto-generated on build.
-
-- [info](https://github.com/dronecore/DroneCore/blob/master/plugins/info/info.h) (plugins/info/info.h): general info about a device
-- [telemetry](https://github.com/dronecore/DroneCore/blob/master/plugins/telemetry/telemetry.h) (plugins/telemetry/telemetry.h): to receive telemetry data
-- [action](https://github.com/dronecore/DroneCore/blob/master/plugins/action/action.h) (plugins/action/action.h): to send commands such as arm, disarm, takeoff, land to drone
-- [mission](https://github.com/dronecore/DroneCore/blob/master/plugins/mission/mission.h) (plugins/mission/mission.h)/[mission_item](https://github.com/dronecore/DroneCore/blob/master/plugins/mission/mission_item.h) (plugins/mission/mission_item.h): to upload a waypoint mission
-- [offboard](https://github.com/dronecore/DroneCore/blob/master/plugins/offboard/offboard.h)(plugins/offboard/offboard.h): for velocity or position control
+This API guide provides topics showing how to use the DroneCore APIs to perform common (and not so common) tasks. Before you read this section you should first review the [API Overview](../README.md#api-overview).
 

--- a/en/guide/general_usage.md
+++ b/en/guide/general_usage.md
@@ -34,7 +34,7 @@ DroneCore `Telemetry` information may not precisely reflect the state of the con
 
 DroneCore gets and stores vehicle state information from received MAVLink messages. The API is likely to more accurately reflect the device state if DroneCore is queried just after receiving an update rather than just before getting the next one.
 
-The main implication is that developers need to use a channel and and update rate that allows them to perform the desired control algorithm - there is no point trying to use computer vision over an unreliable high-latency link. The rate at which update messages should be sent can be specified by using API (but will be limited by the bandwidth of the channel). 
+The main implication is that developers need to use a channel and an update rate that allows them to perform the desired control algorithm - there is no point trying to use computer vision over an unreliable high-latency link. The rate at which update messages should be sent can be specified by using API (but will be limited by the bandwidth of the channel). 
 
 `Info` information is static for a particular vehicle, so should remain accurate.
 
@@ -43,7 +43,7 @@ The main implication is that developers need to use a channel and and update rat
 
 Actions methods (and any other "vehicle instructions") return when the vehicle has confirmed that the message was received and will be acted on (or not). The methods do not wait for the commanded action to complete.
 
-So, for example, the [Action::land()](../api_reference/classdronecore_1_1_action.md#classdronecore_1_1_action_1ad1a50dd7bff99d3099916576efbf8cf6) method returns as soon as the vehicle confirms it will land, but will land at some later point. 
+So, for example, the [Action::land()](../api_reference/classdronecore_1_1_action.md#classdronecore_1_1_action_1ad1a50dd7bff99d3099916576efbf8cf6) method returns as soon as the vehicle confirms it will land, but will actually land at some later point. 
 
 The implication is that developers will need to separately monitor the completion of the requested actions, if this is important to the application.
 

--- a/en/guide/general_usage.md
+++ b/en/guide/general_usage.md
@@ -1,0 +1,59 @@
+# DroneCore Paradigms/Usage
+
+This topic provides general/overview information about how DroneCore is used, designed and some limitations. 
+
+
+## Object Management
+
+[DroneCore](../api_reference/classdronecore_1_1_drone_core.md) is the main library class. API consumers use it to discover and manage vehicles ([Device](../api_reference/classdronecore_1_1_device.md) objects), which in turn provide access to all other drone information and control objects.
+
+DroneCore applications must create a `DroneCore` object and destroy it during application shut down. The object can be created as an automatic variable that is cleaned up when it goes out of scope, or you can dynamically create/destroy the object using `new`/`delete`.
+
+All other objects are returned/owned by the API and will automatically be destroyed along with `DroneCore`.
+
+
+## Error Handling
+
+DroneCore APIs do not raise exceptions! Instead, methods that can fail return success or an error reason as `enum` values.
+
+> **Tip** The error code usually reflects acknowledgment from the vehicle that it will perform the requested action (or not). The operation itself may not yet have completed (e.g. taking off).
+
+The various classes also all provide methods getting human readable strings from their associated enum (e.g. [DroneCore::connection_result_str()](h../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a84c40dcefcafe888c38a5ed8dd93b0af), [Telemetry::result_str()](../api_reference/classdronecore_1_1_telemetry.md#classdronecore_1_1_telemetry_1a05c6355b7f8743250b2a7a611ea5fb4a)). You can see how these are used in the example code.
+
+## API Limitations/Behaviour
+### Supported Vehicles
+
+DroneCore has been designed to manage *aircraft* (VTOL, copter, fixed wing) that use the PX4 autopilot. 
+
+The APIs include methods that do not make sense for other vehicle types - including "takeoff" and "land". While ground vehicles may work, they are not supported and are untested.
+
+
+### Telemetry/Information
+
+DroneCore `Telemetry` information may not precisely reflect the state of the connected vehicle.
+
+DroneCore gets and stores vehicle state information from received MAVLink messages. The API is likely to more accurately reflect the device state if DroneCore is queried just after receiving an update rather than just before getting the next one.
+
+The main implication is that developers need to use a channel and and update rate that allows them to perform the desired control algorithm - there is no point trying to use computer vision over an unreliable high-latency link. The rate at which update messages should be sent can be specified by using API (but will be limited by the bandwidth of the channel). 
+
+`Info` information is static for a particular vehicle, so should remain accurate.
+
+
+### Actions/Offboard
+
+Actions methods (and any other "vehicle instructions") return when the vehicle has confirmed that the message was received and will be acted on (or not). The methods do not wait for the commanded action to complete.
+
+So, for example, the [Action::land()](../api_reference/classdronecore_1_1_action.md#classdronecore_1_1_action_1ad1a50dd7bff99d3099916576efbf8cf6) method returns as soon as the vehicle confirms it will land, but will land at some later point. 
+
+The implication is that developers will need to separately monitor the completion of the requested actions, if this is important to the application.
+
+
+### Missions
+
+The `Mission` and `MissionItem` APIs provide a the most useful *subset* of MAVLink mission commands as a developer-friendly API. 
+
+Not every mission command behaviour supported by the protocol and PX4 will be supported by DroneCore. For example, at time of writing the API does not allow you to specify commands that jump back to previous commands.
+
+### Connection Status
+
+Connection state information may be up to 3 seconds out of date (callbacks are notified 3 seconds after the last heartbeat message).

--- a/en/guide/general_usage.md
+++ b/en/guide/general_usage.md
@@ -18,7 +18,7 @@ DroneCore APIs do not raise exceptions! Instead, methods that can fail return su
 
 > **Tip** The error code usually reflects acknowledgment from the vehicle that it will perform the requested action (or not). The operation itself may not yet have completed (e.g. taking off).
 
-The various classes also all provide methods getting human readable strings from their associated enum (e.g. [DroneCore::connection_result_str()](h../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a84c40dcefcafe888c38a5ed8dd93b0af), [Telemetry::result_str()](../api_reference/classdronecore_1_1_telemetry.md#classdronecore_1_1_telemetry_1a05c6355b7f8743250b2a7a611ea5fb4a)). You can see how these are used in the example code.
+The various classes also all provide methods getting human readable strings from their associated enum (e.g. [DroneCore::connection_result_str()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a84c40dcefcafe888c38a5ed8dd93b0af), [Telemetry::result_str()](../api_reference/classdronecore_1_1_telemetry.md#classdronecore_1_1_telemetry_1a05c6355b7f8743250b2a7a611ea5fb4a)). You can see how these are used in the example code.
 
 ## API Limitations/Behaviour
 ### Supported Vehicles
@@ -30,13 +30,11 @@ The APIs include methods that do not make sense for other vehicle types - includ
 
 ### Telemetry/Information
 
-DroneCore `Telemetry` information may not precisely reflect the state of the connected vehicle.
+DroneCore gets and stores vehicle state/telemetry information from received MAVLink messages. The information is supplied to callback subscribers as soon as message updates are received. Clients can also query the API synchronously, and will get the information from the last recieved message (depending on channel latency, this information will become increasingly "stale" between messages).
 
-DroneCore gets and stores vehicle state information from received MAVLink messages. The API is likely to more accurately reflect the device state if DroneCore is queried just after receiving an update rather than just before getting the next one.
+The rate at which update messages are sent by the vehicle can be specified using DroneCore (but will be limited by the bandwidth of the channel). Developers need to use a channel and a message update rate that allows their desired control algorithm to be effective - there is no point trying to use computer vision over an unreliable high-latency link.
 
-The main implication is that developers need to use a channel and an update rate that allows them to perform the desired control algorithm - there is no point trying to use computer vision over an unreliable high-latency link. The rate at which update messages should be sent can be specified by using API (but will be limited by the bandwidth of the channel). 
-
-`Info` information is static for a particular vehicle, so should remain accurate.
+`Info` information does not change for a particular vehicle, so will be accurate whenever read.
 
 
 ### Actions/Offboard
@@ -52,8 +50,9 @@ The implication is that developers will need to separately monitor the completio
 
 The `Mission` and `MissionItem` APIs provide a the most useful *subset* of MAVLink mission commands as a developer-friendly API. 
 
-Not every mission command behaviour supported by the protocol and PX4 will be supported by DroneCore. For example, at time of writing the API does not allow you to specify commands that jump back to previous commands.
+Not every mission command behaviour supported by the protocol and PX4 will be supported by DroneCore. For example, at time of writing the API does not allow you to specify commands that jump back to previous mission items.
+
 
 ### Connection Status
 
-Connection state information may be up to 3 seconds out of date (callbacks are notified 3 seconds after the last heartbeat message).
+A device is considered to be disconnected (timed-out) if its heartbeat message is not detected within 3 seconds.


### PR DESCRIPTION
@julianoes This adds the guide section and first guide topic. The first topic is supposed to include everything the main "general" knowledge you have to know to use the API - error handling, how to create the library etc. 

Not sure where instructions for the CMakeLists.txt file should live. Possibly here, but more likely in a separate doc. 