### PR TITLE
Add topic explaining how to set up build files for Cpp apps

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -6,6 +6,7 @@
 * [Guide](guide/README.md)
   * [Usage/Paradigms](guide/general_usage.md)
   * [Connecting to Devices](guide/connections.md)
+  * [Building C++ Apps](guide/toolchain.md)
 * [Example](examples/README.md)
   * [Takeoff and Land](examples/takeoff_and_land.md)
 * [API Reference](api_reference/README.md)

--- a/en/contributing/build.md
+++ b/en/contributing/build.md
@@ -254,23 +254,32 @@ You can also build the image yourself using the [Dockerfile](https://github.com/
    ```
 
 
-## Install Artifacts
+## Install DroneCore Headers and Static Library
 
-The build artifacts (headers and static library file) can be installed locally into the folder `./install/` using:
+In order to *use* DroneCore your C++ applications need to be able locate the DroneCore libraries and header files (see [Building C++ Apps](../guide/toolchain.md)). You can either install these to standard system locations or locally within the DroneCore directory.
+
+> **Note** When using the library **libdronecore.a**, you need to link to a thread library such as *pthread* on a POSIX system (pthread is not included in the static library because it is included in glibc).
+
+
+### System-wide Install
+
+Installing DroneCore system-wide means that the files you need to build your apps are always in the same place, and your build definition files can be simpler because they do not need to consider relative locations.
+
+> **Warning** System-wide install is not (yet) supported on Windows. If you're a Windows guru, we'd [love your help](../README.md#getting-help) to set this up.
+
+To install the files system-wide:
+
+```bash
+make clean  #REQUIRED!
+sudo INSTALL_PREFIX=/usr/local make default install
+```
+
+> **Note** System-wide install overwrites standard install locations. If you already have DroneCore installed through some other mechanism it will be replaced!
+
+### Local Install
+
+The DroneCore headers and static library can be installed locally into the folder **DroneCore/install/** using:
 
 ```
 make default install
 ```
-
-Or, to install the files system-wide, using:
-
-```
-INSTALL_PREFIX=/usr/local make default install
-```
-
-Note that when using the library **libdronecore.a**, you need to link to a thread library such as *pthread* on a POSIX system (pthread is not included in the static library because it is included in glibc).
-
-## Build Python Wrapper
-
-TBD.
-

--- a/en/contributing/build.md
+++ b/en/contributing/build.md
@@ -254,7 +254,7 @@ You can also build the image yourself using the [Dockerfile](https://github.com/
    ```
 
 
-## Install DroneCore Headers and Static Library
+## Install DroneCore Headers and Static Library {#install-artifacts}
 
 In order to *use* DroneCore your C++ applications need to be able locate the DroneCore libraries and header files (see [Building C++ Apps](../guide/toolchain.md)). You can either install these to standard system locations or locally within the DroneCore directory.
 

--- a/en/guide/toolchain.md
+++ b/en/guide/toolchain.md
@@ -6,7 +6,7 @@ DroneCore C++ apps are written in standard C++ (c++11) and can be built using yo
 
 DroneCore itself uses the [cmake](https://cmake.org/) build system, and we recommend that you do too. CMake is an open-source, cross-platform toolchain that allows you to build your examples on Mac OS, Linux and Windows using the same build file definition.
 
-Below we explain how to set up a minimal make file for your application.
+Below we explain how to set up a minimal build setup (**CMakeLists.txt**) file for your application.
 
 
 ## Build Definition File - CMakeLists.txt

--- a/en/guide/toolchain.md
+++ b/en/guide/toolchain.md
@@ -1,0 +1,121 @@
+# Building C++ DroneCore Apps
+
+DroneCore C++ apps are written in standard C++ (c++11) and can be built using your preferred build system, compiler and linker toolchain. The only requirements are:
+- The build system must be able to locate the DroneCore headers and libraries (installed as described [here](../contributing/build.html#install-artifacts)).
+- When using the library **libdronecore.a**, you need to link to a thread library such as *pthread* on a POSIX system (*pthread* is not included in the static library because it is included in *glibc*). 
+
+DroneCore itself uses [cmake](https://cmake.org/), and we recommend that you do too. CMake is an open-source, cross-platform toolchain that allows you to build your examples on Mac OS, Linux and Windows using the same build file definition.
+
+Below we explain how to set up a minimal make file for your application.
+
+> **Tip** You can also kick off your application by copying modifying our existing [example code](https://github.com/dronecore/DroneCore/blob/master/example/takeoff_land/). Note that if you move your new application outside of the example directory you will need to update the (relative) paths to the locally installed DroneCore library.
+
+
+## Build Definition File - CMakeLists.txt
+
+*Cmake* uses a definition file named **CMakeLists.txt** to define the project. This specifies the name of the project, compiler flags for different platforms and targets, where to find dependencies (libraries and header files), source files to build, and the name of the generated binary. **CMakeLists.txt** is typically stored in the root directory of your app project.
+
+The first two lines of the file should specify the minimum compatible version of *cmake* and *your* project's name. 
+```cmake
+cmake_minimum_required(VERSION 2.8.12)
+project(your_project_name)
+```
+
+Next add the define flags that are used in compilation on different platforms 
+(you can treat this as boilerplate - it enables relatively strict handling of warnings).
+```cmake
+if(NOT MSVC)
+    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+else()
+    add_definitions("-std=c++11 -WX -W2")
+    set(platform_libs "Ws2_32.lib")
+endif()
+
+# Add DEBUG define for Debug target
+set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
+```
+
+Add the line below to find a thread library on Linux, Mac, and Windows. This is required in order to use DroneCore!
+```cmake
+find_package(Threads REQUIRED)
+```
+
+The `include_directories()` command tells *cmake* where to find locally installed header files (if DroneCore is installed globally this is not required). 
+
+```cmake
+include_directories(
+    # Not needed if installed system-wide
+    ${CMAKE_SOURCE_DIR}/../../install/include
+)
+```
+
+> **Note** The fragment above is taken from one of the DroneCore examples, and specifies a relative path from an example sub-directory to where DroneCore exports the header files by default. 
+> If you have installed DroneCore locally and your application is not located alongside the DroneCore examples you will need to change this. 
+>
+>  Note that `CMAKE_SOURCE_DIR` is the directory in which **CMakeLists.txt** is stored, and provides a useful way of defining relative paths to the header files.
+
+Then use `add_executable()` to specify the name for your generated executable and your source files. 
+```cmake
+add_executable(your_executable_name
+    your_source_file.cpp
+)
+```
+
+The final sections of the file defines the libraries to link against. 
+The first part is used if DroneCore is installed locally, and will have to be modified depending on the relative path from your code to the **DroneCore/install/** directory.
+```cmake
+if(WINDOWS)
+    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
+else()
+    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a")
+endif()
+```
+
+The final section of the file defines the libraries to link against if DroneCore is installed globally.
+```cmake
+target_link_libraries(takeoff_and_land
+    ${dronecore_lib}
+    # If installed system-wide:
+    # dronecore
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${platform_libs}
+)
+```
+
+> **Tip** Getting relative paths right can be difficult. You can use [message()](https://cmake.org/cmake/help/v3.9/command/message.html) to print out debug information in your build:
+```bash
+# Get the location of your CMakeLists.txt file
+message(${CMAKE_SOURCE_DIR})
+```
+
+## Building the App
+
+This section assumes that you have already [built and installed the DroneCore C++ Library](../contributing/build.md) and that your example has a **CMakeLists.txt** in its root directory. 
+
+All we need to do is create a build directory (to keep all our build files in one place) and run the build from there. 
+
+```bash 
+cd /path/to/your/example/  # Open a prompt and navigate to your example 
+mkdir build && cd build   # Create a build directory and navigate into it
+cmake --build .  # Build the current directory
+./your_executable_name  # Run your new executable
+```
+
+
+## Useful Links
+
+We only show a small fraction of what *Cmake* is capable of! Check out the links below for more information and examples.
+
+* [cmake resources page](https://cmake.org/documentation/)
+* [cmake documentation](https://cmake.org/cmake/help/latest/) (latest)
+* [cmake commands](https://cmake.org/cmake/help/latest/manual/cmake-commands.7.html) (used in this example):
+  * [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) - Minimum compatible version of cmake
+  * [project()](https://cmake.org/cmake/help/latest/command/project.html) - Set a name for project (and optionally version, languages, etc.)
+  * [add_definitions()](https://cmake.org/cmake/help/latest/command/add_definitions.html) - Adds -D define flags to the compilation of source files
+  * [set()](https://cmake.org/cmake/help/latest/command/set.html) - Set a normal, cache, or environment variable to a given value
+  * [find_package()](https://cmake.org/cmake/help/latest/command/find_package.html) - Load settings for an external project.
+  * [include_directories()](https://cmake.org/cmake/help/latest/command/include_directories.html)
+  * [add_executable()](https://cmake.org/cmake/help/latest/command/add_executable.html) - Specify executable to be created and set of source files to use
+  * [target_link_libraries()](https://cmake.org/cmake/help/latest/command/target_link_libraries.html) - Specify libraries to use when linking
+  * [message()](https://cmake.org/cmake/help/v3.9/command/message.html) - Display a message to the user
+  

--- a/en/guide/toolchain.md
+++ b/en/guide/toolchain.md
@@ -2,28 +2,31 @@
 
 DroneCore C++ apps are written in standard C++ (c++11) and can be built using your preferred build system, compiler and linker toolchain. The only requirements are:
 - The build system must be able to locate the DroneCore headers and libraries (installed as described [here](../contributing/build.html#install-artifacts)).
-- When using the library **libdronecore.a**, you need to link to a thread library such as *pthread* on a POSIX system (*pthread* is not included in the static library because it is included in *glibc*). 
+- When using DroneCore you need to link to a thread library (e.g. *pthread* on a POSIX system). 
 
-DroneCore itself uses [cmake](https://cmake.org/), and we recommend that you do too. CMake is an open-source, cross-platform toolchain that allows you to build your examples on Mac OS, Linux and Windows using the same build file definition.
+DroneCore itself uses the [cmake](https://cmake.org/) build system, and we recommend that you do too. CMake is an open-source, cross-platform toolchain that allows you to build your examples on Mac OS, Linux and Windows using the same build file definition.
 
 Below we explain how to set up a minimal make file for your application.
-
-> **Tip** You can also kick off your application by copying modifying our existing [example code](https://github.com/dronecore/DroneCore/blob/master/example/takeoff_land/). Note that if you move your new application outside of the example directory you will need to update the (relative) paths to the locally installed DroneCore library.
 
 
 ## Build Definition File - CMakeLists.txt
 
 *Cmake* uses a definition file named **CMakeLists.txt** to define the project. This specifies the name of the project, compiler flags for different platforms and targets, where to find dependencies (libraries and header files), source files to build, and the name of the generated binary. **CMakeLists.txt** is typically stored in the root directory of your app project.
 
-The first two lines of the file should specify the minimum compatible version of *cmake* and *your* project's name. 
+The sections below show how you can set up the file for when DroneCore is installed system-wide or locally.
+
+
+### DroneCore Installed System-wide
+
+> **Warning** System-wide install is not (yet) supported on Windows (if you're a Windows guru, we'd [love your help](../README.md#getting-help) to implement this). You will have to use install locally as shown in the following section. 
+
+A "template" **CMakeLists.txt** is shown below. Almost all of the above file is boilerplate - the only things you need to change are *your_project_name*, *your_executable_name* and *your_source_file*. 
+
 ```cmake
 cmake_minimum_required(VERSION 2.8.12)
 project(your_project_name)
-```
 
-Next add the define flags that are used in compilation on different platforms 
-(you can treat this as boilerplate - it enables relatively strict handling of warnings).
-```cmake
+# Add platform/compiler specific flags
 if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
@@ -33,73 +36,169 @@ endif()
 
 # Add DEBUG define for Debug target
 set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
-```
 
-Add the line below to find a thread library on Linux, Mac, and Windows. This is required in order to use DroneCore!
-```cmake
+# This finds thread libs on Linux, Mac, and Windows.
 find_package(Threads REQUIRED)
+
+# Specify your binary name, and list of source files used to create it.
+add_executable(your_executable_name
+    your_source_file.cpp
+)
+
+target_link_libraries(your_executable_name
+    dronecore  # Link against library named dronecore in standard install location
+    ${CMAKE_THREAD_LIBS_INIT}  # Link against thread library found using find_package() 
+    ${platform_libs}  # Variable containing all libraries that to link against for this platform (e.g. pthread).
+)
 ```
 
-The `include_directories()` command tells *cmake* where to find locally installed header files (if DroneCore is installed globally this is not required). 
+> **Tip** The make file can be so minimal because the `target_link_libraries()` function has the `dronecore` line, which tells *cmake* that DroneCore's library and headers are in the standard location.
+
+We'll explain some of it in the next section.
+
+
+### DroneCore Installed Locally
+
+The **CMakeLists.txt** is more complicated when DroneCore is installed locally, because you need to specify where the build should find both headers and library files. 
+
+The new lines are marked up using `# >>> ADDED` comments below.  You have to change the same information as before: *your_project_name*, *your_executable_name* and *your_source_file*. You may also need to change the location of the headers/library files, depending on where your application is hosted relative to the **DroneCore** project root directory (this example assumes that your application is nested two levels deep, just like our example code).
 
 ```cmake
+cmake_minimum_required(VERSION 2.8.12)
+project(your_project_name)
+
+# Add platform/compiler specific flags
+if(NOT MSVC)
+    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+else()
+    add_definitions("-std=c++11 -WX -W2")
+    set(platform_libs "Ws2_32.lib")
+endif()
+
+# Add DEBUG define for Debug target
+set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
+
+# This finds thread libs on Linux, Mac, and Windows.
+find_package(Threads REQUIRED)
+
+# >>> ADDED
+# Specify include directories
 include_directories(
     # Not needed if installed system-wide
     ${CMAKE_SOURCE_DIR}/../../install/include
 )
-```
+# <<< 
 
-> **Note** The fragment above is taken from one of the DroneCore examples, and specifies a relative path from an example sub-directory to where DroneCore exports the header files by default. 
-> If you have installed DroneCore locally and your application is not located alongside the DroneCore examples you will need to change this. 
->
->  Note that `CMAKE_SOURCE_DIR` is the directory in which **CMakeLists.txt** is stored, and provides a useful way of defining relative paths to the header files.
-
-Then use `add_executable()` to specify the name for your generated executable and your source files. 
-```cmake
+# Specify your binary name, and list of source files used to create it.
 add_executable(your_executable_name
     your_source_file.cpp
 )
-```
 
-The final sections of the file defines the libraries to link against. 
-The first part is used if DroneCore is installed locally, and will have to be modified depending on the relative path from your code to the **DroneCore/install/** directory.
-```cmake
+# >>> ADDED
+# Specify variable 'dronecore_lib' containing location of DroneCore library.
 if(WINDOWS)
     set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
 else()
     set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a")
 endif()
-```
+# <<< 
 
-The final section of the file defines the libraries to link against if DroneCore is installed globally.
-```cmake
-target_link_libraries(takeoff_and_land
+target_link_libraries(your_executable_name
+# >>> ADDED
+    # Add  'dronecore_lib' variable defining where the dronecore library can be found. 
     ${dronecore_lib}
-    # If installed system-wide:
-    # dronecore
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${platform_libs}
+    # dronecore # Link against library named dronecore in standard install location
+# <<< 
+    ${CMAKE_THREAD_LIBS_INIT}  # Link against thread library found using find_package() 
+    ${platform_libs}  # Variable containing all libraries that to link against for this platform (e.g. pthread).
 )
 ```
 
-> **Tip** Getting relative paths right can be difficult. You can use [message()](https://cmake.org/cmake/help/v3.9/command/message.html) to print out debug information in your build:
-```bash
-# Get the location of your CMakeLists.txt file
-message(${CMAKE_SOURCE_DIR})
+
+The main elements of the file are described below:
+
+1. The first two lines of the file should specify the minimum compatible version of *cmake* and *your* project's name.
+   ```cmake
+   cmake_minimum_required(VERSION 2.8.12)
+   project(your_project_name)
+   ```
+1. The [add_definitions()](https://cmake.org/cmake/help/latest/command/add_definitions.html) and [set()](https://cmake.org/cmake/help/latest/command/set.html) are used to the define flags that are used in compilation on different platforms. In this case we enable strict handling of warnings and an MSVC specific library.
+   ```cmake
+   if(NOT MSVC)
+       add_definitions("-std=c++11 -Wall -Wextra -Werror")
+   else()
+       add_definitions("-std=c++11 -WX -W2")
+       set(platform_libs "Ws2_32.lib")
+   endif()
+
+   # Add DEBUG define for Debug target
+   set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
+   ```
+1. The [find_package()](https://cmake.org/cmake/help/latest/command/find_package.html) command tells *cmake* to find a thread library on Linux, Mac, and Windows. Further down we add the found package to the libraries built into the project (see `${CMAKE_THREAD_LIBS_INIT}`):
+   ```cmake
+   find_package(Threads REQUIRED)
+   ```
+   This is required in order to use DroneCore!
+
+1. The [include_directories()](https://cmake.org/cmake/help/latest/command/include_directories.html) tells *cmake* where to find locally installed header files (if DroneCore is installed globally this is not required). 
+   ```cmake
+   include_directories(
+       # Not needed if installed system-wide
+       ${CMAKE_SOURCE_DIR}/../../install/include
+   )
+   ```
+
+   > **Note** `CMAKE_SOURCE_DIR` is the directory in which **CMakeLists.txt** is stored, and provides a useful way of defining relative paths to the header files. This example assumes that your application is nested two levels deep, in order to access the include files installed locally to: **/Dronecore/install/include**.
+1. The [add_executable()](https://cmake.org/cmake/help/latest/command/add_executable.html) command specifies the name for your generated executable and your source file(s). 
+   ```cmake
+   add_executable(your_executable_name
+       your_source_file.cpp
+   )
+  ```
+1. Here we define a variable for the location of the DroneCore library, depending on platform. As for the include files, this requires a relative path (to **DroneCore/install/lib/*). This is then used in the next step.
+   ```cmake
+   if(WINDOWS)
+       set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
+   else()
+       set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a")
+   endif()
+   ```
+1. The [target_link_libraries()](https://cmake.org/cmake/help/latest/command/target_link_libraries.html) command defines the libraries that your executable (`your_executable_name`) will link against. Here we use the `${dronecore_lib}` variable defined above. We comment out the `dronecore`, because the two definitions for libraries conflict.
+```cmake
+target_link_libraries(your_executable_name
+    ${dronecore_lib}
+    # If installed system-wide:
+    # dronecore
+    ${CMAKE_THREAD_LIBS_INIT}  # Link against thread library found using find_package() 
+    ${platform_libs}  # Variable containing all libraries that to link against for this platform (e.g. pthread).
+)
 ```
+
 
 ## Building the App
 
 This section assumes that you have already [built and installed the DroneCore C++ Library](../contributing/build.md) and that your example has a **CMakeLists.txt** in its root directory. 
 
-All we need to do is create a build directory (to keep all our build files in one place) and run the build from there. 
-
-```bash 
-cd /path/to/your/example/  # Open a prompt and navigate to your example 
-mkdir build && cd build   # Create a build directory and navigate into it
-cmake --build .  # Build the current directory
-./your_executable_name  # Run your new executable
-```
+To create and run the app:
+1. First create a build directory and run *cmake*: 
+   ```bash 
+   cd /path/to/your/application/   # Open a prompt and navigate to your application 
+   mkdir build && cd build   # Create a build directory and navigate into it
+   cmake ..   # Create make files for your current platform
+   ```
+1. Build the project
+   * Linux/Mac:
+     ```bash 
+     make -j8
+     ``` 
+   * Windows:
+     ```bash 
+     cmake --build .
+     ``` 
+1. Execute the file (in your build directory):
+     ```bash 
+     ./your_executable_name  # Run your new executable
+     ```
 
 
 ## Useful Links
@@ -108,14 +207,7 @@ We only show a small fraction of what *Cmake* is capable of! Check out the links
 
 * [cmake resources page](https://cmake.org/documentation/)
 * [cmake documentation](https://cmake.org/cmake/help/latest/) (latest)
-* [cmake commands](https://cmake.org/cmake/help/latest/manual/cmake-commands.7.html) (used in this example):
-  * [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) - Minimum compatible version of cmake
-  * [project()](https://cmake.org/cmake/help/latest/command/project.html) - Set a name for project (and optionally version, languages, etc.)
-  * [add_definitions()](https://cmake.org/cmake/help/latest/command/add_definitions.html) - Adds -D define flags to the compilation of source files
-  * [set()](https://cmake.org/cmake/help/latest/command/set.html) - Set a normal, cache, or environment variable to a given value
-  * [find_package()](https://cmake.org/cmake/help/latest/command/find_package.html) - Load settings for an external project.
-  * [include_directories()](https://cmake.org/cmake/help/latest/command/include_directories.html)
-  * [add_executable()](https://cmake.org/cmake/help/latest/command/add_executable.html) - Specify executable to be created and set of source files to use
-  * [target_link_libraries()](https://cmake.org/cmake/help/latest/command/target_link_libraries.html) - Specify libraries to use when linking
-  * [message()](https://cmake.org/cmake/help/v3.9/command/message.html) - Display a message to the user
+* [cmake commands](https://cmake.org/cmake/help/latest/manual/cmake-commands.7.html)
+
+
   


### PR DESCRIPTION
This explains 
- the requirements for a build system (essentially anything you like, as long as it can find the libs/headers for DroneCore AND it adds the needed thread library).
- The minimum setup if you want to use cmake, based on our example code.

It does feel a little ponderous (mostly because of the relative paths), but anyone wanting to build apps is going to have to go down this path, and I think having an explanation helps. 