### PR TITLE
Info add vendor product 118

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -19,6 +19,7 @@
   * [class Device](api_reference/classdronecore_1_1_device.md)
   * [class Info](api_reference/classdronecore_1_1_info.md)
     * [struct Version](api_reference/structdronecore_1_1_info_1_1_version.md)
+    * [struct Product](api_reference/structdronecore_1_1_info_1_1_product.md)
   * [class Telemetry](api_reference/classdronecore_1_1_telemetry.md)
     * [struct Battery](api_reference/structdronecore_1_1_telemetry_1_1_battery.md)
     * [struct EulerAngle](api_reference/structdronecore_1_1_telemetry_1_1_euler_angle.md)

--- a/en/api_reference/README.md
+++ b/en/api_reference/README.md
@@ -4,6 +4,7 @@
 * [class Device](classdronecore_1_1_device.md)
 * [class Info](classdronecore_1_1_info.md)
   * [struct Version](structdronecore_1_1_info_1_1_version.md)
+  * [struct Product](structdronecore_1_1_info_1_1_product.md)
 * [class Telemetry](classdronecore_1_1_telemetry.md)
   * [struct Battery](structdronecore_1_1_telemetry_1_1_battery.md)
   * [struct EulerAngle](structdronecore_1_1_telemetry_1_1_euler_angle.md)

--- a/en/api_reference/classdronecore_1_1_info.md
+++ b/en/api_reference/classdronecore_1_1_info.md
@@ -10,6 +10,8 @@ The [Info](classdronecore_1_1_info.md) class provides basic infomation about the
 ## Data Structures
 
 
+struct [Product](structdronecore_1_1_info_1_1_product.md)
+
 struct [Version](structdronecore_1_1_info_1_1_version.md)
 
 ## Public Member Functions
@@ -23,6 +25,7 @@ Type | Name | Description
 uint64_t | [uuid](#classdronecore_1_1_info_1a49c7dd5f1a369c8296f0c3a2443bc031) () const | Gets the UUID of the device.
 bool | [is_complete](#classdronecore_1_1_info_1a088438b73c715fb20c02792fed1815f7) () const | Tests if this [Version](structdronecore_1_1_info_1_1_version.md) object is fully populated from hardware.
 [Version](structdronecore_1_1_info_1_1_version.md) | [get_version](#classdronecore_1_1_info_1a6e41fae8c6ad352e70b1e93b4a1589f9) () const | Get device version information.
+[Product](structdronecore_1_1_info_1_1_product.md) | [get_product](#classdronecore_1_1_info_1adb7999bf9e92f95e3dfa5eaea216807a) () const | Get device product information.
 const [Info](classdronecore_1_1_info.md) & | [operator=](#classdronecore_1_1_info_1ac82758b486f00562e193a89e3dbff6d3) (const Info &)=delete | Equality operator (object is not copyable).
 
 ## Static Public Attributes
@@ -111,6 +114,19 @@ Get device version information.
 **Returns**
 
 &emsp;[Version](structdronecore_1_1_info_1_1_version.md) - The version object for the device.
+
+### get_product() {#classdronecore_1_1_info_1adb7999bf9e92f95e3dfa5eaea216807a}
+```cpp
+Product dronecore::Info::get_product() const
+```
+
+
+Get device product information.
+
+
+**Returns**
+
+&emsp;[Product](structdronecore_1_1_info_1_1_product.md) - The product object for the device.
 
 ### operator=() {#classdronecore_1_1_info_1ac82758b486f00562e193a89e3dbff6d3}
 ```cpp

--- a/en/api_reference/structdronecore_1_1_info_1_1_product.md
+++ b/en/api_reference/structdronecore_1_1_info_1_1_product.md
@@ -1,0 +1,66 @@
+# dronecore::Info::Product Struct Reference
+`#include: info.h`
+
+----
+
+
+Type containing device product information. 
+
+
+## Data Fields
+
+
+ int [vendor_id](#structdronecore_1_1_info_1_1_product_1a6e65d6271113bc484ce5a979b200deaa) - ID of board vendor.
+
+
+ char [vendor_name](#structdronecore_1_1_info_1_1_product_1aa4087d0be4f4f55d2a017ab794bdec12) - Name of vendor.
+
+
+ int [product_id](#structdronecore_1_1_info_1_1_product_1a1194de2d7f34e3f001ae060d425b4dba) - ID of product.
+
+
+ char [product_name](#structdronecore_1_1_info_1_1_product_1a8522bb729957f8353ff2e5f98c398082) - Name of product.
+
+
+## Field Documentation
+
+
+### vendor_id {#structdronecore_1_1_info_1_1_product_1a6e65d6271113bc484ce5a979b200deaa}
+
+```cpp
+int dronecore::Info::Product::vendor_id
+```
+
+
+ID of board vendor.
+
+
+### vendor_name {#structdronecore_1_1_info_1_1_product_1aa4087d0be4f4f55d2a017ab794bdec12}
+
+```cpp
+char dronecore::Info::Product::vendor_name[32]
+```
+
+
+Name of vendor.
+
+
+### product_id {#structdronecore_1_1_info_1_1_product_1a1194de2d7f34e3f001ae060d425b4dba}
+
+```cpp
+int dronecore::Info::Product::product_id
+```
+
+
+ID of product.
+
+
+### product_name {#structdronecore_1_1_info_1_1_product_1a8522bb729957f8353ff2e5f98c398082}
+
+```cpp
+char dronecore::Info::Product::product_name[32]
+```
+
+
+Name of product.
+

--- a/en/api_reference/structdronecore_1_1_info_1_1_version.md
+++ b/en/api_reference/structdronecore_1_1_info_1_1_version.md
@@ -43,12 +43,6 @@ Type containing device version information.
  char [os_sw_git_hash](#structdronecore_1_1_info_1_1_version_1a0466e10843ca6a745c39f254ef08cf0f) - Operating system software git hash as string.
 
 
- uint16_t [vendor_id](#structdronecore_1_1_info_1_1_version_1a98d1c4e51637d6fdff5e1fc270d9a947) - ID of board vendor.
-
-
- uint16_t [product_id](#structdronecore_1_1_info_1_1_version_1a1fecccba3c564b65f757205160b8050e) - ID of product.
-
-
 ## Field Documentation
 
 
@@ -160,24 +154,4 @@ char dronecore::Info::Version::os_sw_git_hash[GIT_HASH_STR_LEN]
 
 
 Operating system software git hash as string.
-
-
-### vendor_id {#structdronecore_1_1_info_1_1_version_1a98d1c4e51637d6fdff5e1fc270d9a947}
-
-```cpp
-uint16_t dronecore::Info::Version::vendor_id
-```
-
-
-ID of board vendor.
-
-
-### product_id {#structdronecore_1_1_info_1_1_version_1a1fecccba3c564b65f757205160b8050e}
-
-```cpp
-uint16_t dronecore::Info::Version::product_id
-```
-
-
-ID of product.
 

--- a/en/guide/device_version.md
+++ b/en/guide/device_version.md
@@ -1,12 +1,12 @@
 ## Device Information
 
-The [Info](../api_reference/classdronecore_1_1_info.md) class is used to get device information, including the device UUID (MAVLink `SYS_ID` if no UUID is stored in hardware), PX4 firmware version, vendor firmware version, host OS version (e.g. for NuttX) and vendor and product ids. 
+The [Info](../api_reference/classdronecore_1_1_info.md) class is used to get device information, including the device UUID (MAVLink `SYS_ID` if no UUID is stored in hardware), PX4 firmware version, vendor firmware version, host OS version (e.g. for NuttX) and vendor and product ids/names. 
 
 > **Note** Not all version information will necessarily be relevant on all vehicles. Where this occurs the 
 hardware may return garbage values (for example, the simulator provides garbage values for the vendor 
 firmware semantic version).
 
-The code below shows how to query the UUID and version information and print it to the console:
+The code below shows how to query the UUID, version, and product, information and print it to the console:
 
 ```cpp
 // Get Device to query (the code assumes we have already found at least one vehicle and we 
@@ -36,9 +36,16 @@ std::cout << "  flight_sw_major: " << deviceVersion.flight_sw_major<< std::endl
           << "  os_sw_major: " << deviceVersion.os_sw_major<< std::endl
           << "  os_sw_minor: " << deviceVersion.os_sw_minor<< std::endl
           << "  os_sw_patch: " << deviceVersion.os_sw_patch<< std::endl
-          << "  os_sw_git_hash: " << deviceVersion.os_sw_git_hash<< std::endl
-          << "  vendor_id: " << deviceVersion.vendor_id<< std::endl
-          << "  product_id: " << deviceVersion.product_id<< std::endl;
+          << "  os_sw_git_hash: " << deviceVersion.os_sw_git_hash<< std::endl;
+
+// Get the device Product struct
+const Info::Product &deviceProduct =  device.info().get_product();
+
+// Print out the vehicle product information.
+std::cout << "  vendor_id: " << deviceProduct.vendor_id<< std::endl
+          << "  vendor_name: " << deviceProduct.vendor_name<< std::endl
+          << "  product_id: " << deviceProduct.product_id<< std::endl
+          << "  product_name: " << deviceProduct.product_id<< std::endl;
 ```
 
-> **Tip** It is possible to query for the version before all values have been retrieved. Note above how we use `Info::is_complete()` to check that the version information (`Info::Version`) has all been obtained from the vehicle before printing it.
+> **Tip** It is possible to query for the information before all values have been retrieved. Note above how we use `Info::is_complete()` to check that the version information (`Info::Version` and `Info::Product`) has all been obtained from the vehicle before printing it.


### PR DESCRIPTION
This updates the api reference and guide for new `Info::Product` struct (and changes in `Info::Version`). Ie it is the docs that match this update: https://github.com/dronecore/DroneCore/pull/118

It may need further revision when https://github.com/dronecore/DroneCore/issues/132 is discussed. 