### PR TITLE
Fix links and specify github paths relative to variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 
 script: 
 
-- htmlproofer ./_book --empty-alt-ignore true --check-external-hash true --url-ignore https://img.shields.io/badge/discuss-DroneCore-ff69b4.svg,https://grpc.io/
+- htmlproofer ./_book --empty-alt-ignore true --check-external-hash true --url-ignore 'https://img.shields.io/badge/discuss-DroneCore-ff69b4.svg,https://grpc.io/'
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 
 script: 
 
-- htmlproofer ./_book --empty-alt-ignore true --check-external-hash true
+- htmlproofer ./_book --empty-alt-ignore true --check-external-hash true --url-ignore https://img.shields.io/badge/discuss-DroneCore-ff69b4.svg,https://grpc.io/
 
 
 

--- a/book.json
+++ b/book.json
@@ -13,6 +13,9 @@
         "validate-links",
         "theme-dronecode@git+https://github.com/dronecode/theme-dronecode.git"
     ],
+    "variables": {
+      "github_branch": "develop"
+    },
     "pluginsConfig": {
 
         "page-footer-ex":{

--- a/en/README.md
+++ b/en/README.md
@@ -23,7 +23,7 @@ DroneCore is still in pre-alpha development.
 - Currently you can only develop in C++. 
   - [gRPC](https://grpc.io/) is being investigated as a promising technology for writing the cross-platform wrappers.
 
-To use DroneCore you will need to [build the C++ library](contributing/build.md). The [Guide](guide/README.md) explains how to write C++ DroneCore apps. A simple complete example can be found in [Takeoff and Land](examples/takeoff_and_land.md).
+To use DroneCore you will need to [build the C++ library](contributing/build.md). The [Guide](guide/README.md) explains how to write C++ DroneCore apps. A number complete examples can be found [here](examples/README.md).
 
 
 ## Library Features
@@ -63,7 +63,7 @@ The most important classes are:
 - [Offboard](/api_reference/classdronecore_1_1_offboard.md): Control a drone with velocity commands.
 - [Gimbal](/api_reference/classdronecore_1_1_gimbal.md): Control a gimbal.
 - [Logging](/api_reference/classdronecore_1_1_logging.md): Data logging and streaming from the vehicle.
-- [include/device_plugin_container.h.in](https://github.com/dronecore/DroneCore/blob/master/include/device_plugin_container.h.in): Auto-generated file that is required for DroneCore plugin development - see [DevicePluginContainer](/api_reference/classdronecore_1_1_device_plugin_container.md).
+- [include/device_plugin_container.h.in](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/include/device_plugin_container.h.in): Auto-generated file that is required for DroneCore plugin development - see [DevicePluginContainer](/api_reference/classdronecore_1_1_device_plugin_container.md).
 
 
 ## Getting Started
@@ -95,5 +95,5 @@ The [Contributing](contributing/README.md) section contains everything you need 
 
 ## License
 
-* DroneCore is licensed under the permissive [BSD 3-clause](https://github.com/dronecore/DroneCore/blob/master/LICENSE.md).
+* DroneCore is licensed under the permissive [BSD 3-clause](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/LICENSE.md).
 * This *DroneCore Developer Documentation* is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) license.

--- a/en/contributing/code_style.md
+++ b/en/contributing/code_style.md
@@ -7,7 +7,7 @@ This topic contains the DroneCore formatting and coding guidelines.
 
 ## Formatting and White Space
 
-All **.cpp** and **.h** files should be formatted according to the [astyle](http://astyle.sourceforge.net/) settings defined by [astylerc](https://github.com/dronecore/DroneCore/blob/master/astylerc).
+All **.cpp** and **.h** files should be formatted according to the [astyle](http://astyle.sourceforge.net/) settings defined by [astylerc](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/astylerc).
 
 To automatically fix the formatting, run the command:
 

--- a/en/contributing/dev_logging.md
+++ b/en/contributing/dev_logging.md
@@ -9,7 +9,7 @@ The API methods display a custom message, prepending a timestamp and the type of
 
 ## Usage
 
-The API is defined in [core/log.h](https://github.com/dronecore/DroneCore/blob/master/core/log.h) (and made available to integration tests via [core/integration_test_helper.h](https://github.com/dronecore/DroneCore/blob/master/core/integration_test_helper.h)). 
+The API is defined in [core/log.h](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/core/log.h) (and made available to integration tests via [core/integration_test_helper.h](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/core/integration_test_helper.h)). 
 
 The API methods are called as shown below for `LogDebug()`, with the left shift operator (`<<`) used to append the message-specific text.
 

--- a/en/contributing/documentation.md
+++ b/en/contributing/documentation.md
@@ -51,7 +51,7 @@ For setup information see: [Gitbook toolchain](https://toolchain.gitbook.com/set
 
 ## API Reference
 
-The C++ source code is annotated using comments using [Doxygen](https://www.stack.nl/~dimitri/doxygen/manual/index.html) syntax. You can extract the documentation to markdown files (one per class) when you [build the library](../contributing/build.md).
+The C++ source code is annotated using comments using [Doxygen](http://doxygen.nl/manual/index.html) syntax. You can extract the documentation to markdown files (one per class) when you [build the library](../contributing/build.md).
 
 To create the reference markdown docs (on macOS or Linux) build with: 
 ```
@@ -60,8 +60,8 @@ make docs
 The files are created in **/install/docs/markdown**.
 
 In order to include new API reference in the *DroneCore Guide* it must be manually added to the [Github repository](https://github.com/dronecore/docs/):
-* Copy the files into the [docs/en/api_reference](https://github.com/dronecore/docs/tree/master/en/api_reference) folder
-* *New* APIs should be added to appropriate sections in the [docs/en/SUMMARY.md](https://github.com/dronecore/docs/blob/master/en/SUMMARY.md), [docs/en/api_reference/README.md](https://github.com/dronecore/docs/blob/master/en/api_reference/README.md) and overview [docs/en/README.md](https://github.com/dronecore/docs/blob/master/en/README.md#api-overview).
+* Copy the files into the [docs/en/api_reference](https://github.com/dronecore/docs/tree/{{ book.github_branch }}/en/api_reference) folder
+* *New* APIs should be added to appropriate sections in the [docs/en/SUMMARY.md](https://github.com/dronecore/docs/blob/{{ book.github_branch }}/en/SUMMARY.md), [docs/en/api_reference/README.md](https://github.com/dronecore/docs/blob/{{ book.github_branch }}/en/api_reference/README.md) and overview [docs/en/README.md](https://github.com/dronecore/docs/blob/{{ book.github_branch }}/en/README.md#api-overview).
 
 > **Note** Extracting the API reference does not work automatically on Windows because the `make` toolchain is different. 
 

--- a/en/contributing/plugins.md
+++ b/en/contributing/plugins.md
@@ -1,8 +1,8 @@
 # Writing Plugins
 
-DroneCore is split into a [core](https://github.com/dronecore/DroneCore/tree/master/core) and [plugins](https://github.com/dronecore/DroneCore/tree/master/plugins). 
+DroneCore is split into a [core](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/core) and [plugins](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/plugins). 
 
-Plugins that are located in the *correct location* (a subfolder of **/plugins**) and have the *correct structure* are included at compile time. The *cmake* script [autogenerate_plugin_container.cmake](https://github.com/dronecore/DroneCore/blob/master/autogenerate_plugin_container.cmake) takes care of including the plugin folders and integration tests.
+Plugins that are located in the *correct location* (a subfolder of **/plugins**) and have the *correct structure* are included at compile time. The *cmake* script [autogenerate_plugin_container.cmake](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/autogenerate_plugin_container.cmake) takes care of including the plugin folders and integration tests.
 
 > **Note** Plugins can also be defined in [DroneCore Extensions](../guide/dronecore_extensions.md). 
 > These are defined and tested in exactly the same way as "standard" DroneCore plugins. 
@@ -45,11 +45,11 @@ Each plugin must have the same files/structure, as shown for the "example" plugi
 
 ## Create a Plugin
 
-To create a new C++ plugin, duplicate either a [standard plugin](https://github.com/dronecore/DroneCore/tree/master/plugins) (e.g. 
-[Action](https://github.com/dronecore/DroneCore/tree/master/plugins/action), 
-[Telemetry](https://github.com/dronecore/DroneCore/tree/master/plugins/telemetry), etc.) or the [example](https://github.com/dronecore/DroneCore/tree/master/external_example/plugins/example/) plugin into the **plugins** directory (either in the DroneCore tree or a [DroneCore Extension](../guide/dronecore_extensions.md) folder).
+To create a new C++ plugin, duplicate either a [standard plugin](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/plugins) (e.g. 
+[Action](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/plugins/action), 
+[Telemetry](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/plugins/telemetry), etc.) or the [example](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/external_example/plugins/example/) plugin into the **plugins** directory (either in the DroneCore tree or a [DroneCore Extension](../guide/dronecore_extensions.md) folder).
 
-Modify the plugin as needed and update its [CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/master/external_example/plugins/example/CMakeLists.txt) as appropriate:
+Modify the plugin as needed and update its [CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/external_example/plugins/example/CMakeLists.txt) as appropriate:
 * Modify plugin filenames as appropriate
 * Add additional libraries using the variable `additional_libs`:
   ```
@@ -59,18 +59,18 @@ Modify the plugin as needed and update its [CMakeLists.txt](https://github.com/d
   ```
   set(additional_includes "include_dir" PARENT_SCOPE)
   ```
-* You can also add tests with `unittest_source_files`, as discussed in [Testing](../contributing/test.md#writing_tests).
+* You can also add tests with `unittest_source_files`, as [discussed below](#adding_unit_tests).
 
 
 ## Plugin Code
 
-The [standard plugins](https://github.com/dronecore/DroneCore/tree/master/plugins) can be reviewed for guidance on
+The [standard plugins](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/plugins) can be reviewed for guidance on
 how to write plugin code, including how to send and process MAVLink messages.
 
 
 ## Test Code {#testing}
 
-[Tests](../contributing/test.md#writing_tests) must be created for all new and updated plugin code. 
+Tests must be created for all new and updated plugin code. 
 The tests should be exhaustive, and cover all aspects of using the plugin API.
 
 The [Google Test Primer](https://github.com/google/googletest/blob/master/googletest/docs/Primer.md)
@@ -87,7 +87,7 @@ Unit tests are therefore considered optional!
 
 > **Tip** Comprehensive integration tests should be written instead, with the simulator providing appropriate MAVLink messages.
 
-#### Adding Unit Tests
+#### Adding Unit Tests {#adding_unit_tests}
 
 Unit tests are stored as separate files in the same directory as their associated source code. 
 Often they test the implementation (rather than the public API), 
@@ -107,7 +107,7 @@ set(unittest_source_files
 )
 ```
 
-> **Note** Unit tests for *core* functionality are added in the main [DroneCore/CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/master/CMakeLists.txt#L187) file. 
+> **Note** Unit tests for *core* functionality are added in the main [DroneCore/CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/CMakeLists.txt#L187) file. 
 
 
 #### Unit Test Code
@@ -115,7 +115,7 @@ set(unittest_source_files
 Unit tests typically include the file to be tested, **dronecore.h**, and **gtest.h**. There are no standard shared test unit resources so 
 test functions are declared using `TEST`. All tests in a file should share the same test-case name (the first argument to `TEST`).
 
-The skeleton [example plugin unit test](https://github.com/dronecore/DroneCore/blob/master/external_example/plugins/example/example_impl_test.cpp) is shown below: 
+The skeleton [example plugin unit test](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/external_example/plugins/example/example_impl_test.cpp) is shown below: 
 ```cpp
 #include "example_impl.h"
 #include "dronecore.h"
@@ -134,7 +134,7 @@ TEST(ExampleImpl, NoTest)
 
 
 
-### Writing Integration Tests
+### Writing Integration Tests {#integration_tests}
 
 DroneCore provides the `integration_tests_runner` application for running the integration tests and 
 some helper code to make it easier to log tests and run them against the simulator.
@@ -220,11 +220,9 @@ TEST_F(SitlTest, ExternalExampleHello)
 ```
 
 
-
-
 ## Example Code
 
-> **Note** It is quicker and easier to write and modify [integration tests](#test-code) than examples. 
+> **Note** It is quicker and easier to write and modify [integration tests](#integration_tests) than examples. 
 > Do not write example code until the plugin has been accepted!
 
 A simple example should be written that demonstrates basic usage of its API by 3rd parties. 
@@ -239,7 +237,7 @@ can usefully be copied and reused by external developers.
 
 ### In-Source Comments
 
-The public API must be fully documented using [Doxygen](https://www.stack.nl/~dimitri/doxygen/manual/docblocks.html) markup.
+The public API must be fully documented using [Doxygen](http://doxygen.nl/manual/docblocks.html) markup.
 All items should minimally have a brief description (preceded by the `@brief` tag).
 
 > **Tip** The in-source comments will be compiled to markdown and included in the [API Reference](../api_reference/README.md).

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-> **Tip** Information about *writing* example code is covered in the [Contributing > Writing Plugins](../contributing/plugins.md) (*plugin developers* should initially create [integration tests](../contributing/test.md#integration-tests) rather than examples for new code).
+> **Tip** Information about *writing* example code is covered in the [Contributing > Writing Plugins](../contributing/plugins.md) (*plugin developers* should initially create [integration tests](../contributing/plugins.md#integration_tests) rather than examples for new code).
 
 This section contains examples showing how to use DroneCore.
 

--- a/en/examples/fly_mission.md
+++ b/en/examples/fly_mission.md
@@ -67,10 +67,10 @@ The operation of most of this code is discussed in the guide: [Missions](../guid
 
 ## Source code {#source_code}
 
-> **Tip** The full source code for the example [can be found on Github here](https://github.com/dronecore/DroneCore/tree/master/example/fly_mission).
+> **Tip** The full source code for the example [can be found on Github here](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/example/fly_mission).
 
 
-[CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/master/example/fly_mission/CMakeLists.txt)
+[CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/example/fly_mission/CMakeLists.txt)
 
 ```make
 cmake_minimum_required(VERSION 2.8.12)
@@ -114,7 +114,7 @@ target_link_libraries(fly_mission
 )
 ```
 
-[fly_mission.cpp](https://github.com/dronecore/DroneCore/blob/master/example/fly_mission/fly_mission.cpp)
+[fly_mission.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/example/fly_mission/fly_mission.cpp)
 
 ```cpp
 //

--- a/en/examples/offboard_velocity.md
+++ b/en/examples/offboard_velocity.md
@@ -54,10 +54,10 @@ The operation of most of this code is discussed in the guide: [Offboard Control]
 
 ## Source code {#source_code}
 
-> **Tip** The full source code for the example [can be found on Github here](https://github.com/dronecore/DroneCore/tree/master/example/offboard_velocity).
+> **Tip** The full source code for the example [can be found on Github here](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/example/offboard_velocity).
 
 
-[CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/master/example/offboard_velocity/CMakeLists.txt)
+[CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/example/offboard_velocity/CMakeLists.txt)
 
 ```make
 cmake_minimum_required(VERSION 2.8.12)
@@ -101,7 +101,7 @@ target_link_libraries(offboard
 )
 ```
 
-[offboard_velocity.cpp](https://github.com/dronecore/DroneCore/blob/master/example/offboard_velocity/offboard_velocity.cpp)
+[offboard_velocity.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/example/offboard_velocity/offboard_velocity.cpp)
 
 ```cpp
 /**

--- a/en/examples/takeoff_and_land.md
+++ b/en/examples/takeoff_and_land.md
@@ -4,7 +4,7 @@ This simple example shows the basic use of many DroneCore features.
 
 It sets up a UDP connection, waits for a device to appear, arms it, and commands it to takeoff and then land again. While flying the vehicle receives telemetry. The example is implemented in C++ (only).
 
-> **Tip** The full source code for the example [can be found here](https://github.com/dronecore/DroneCore/tree/master/example/takeoff_land).
+> **Tip** The full source code for the example [can be found here](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/example/takeoff_land).
 
 ## Running the Example {#run_example}
 
@@ -40,9 +40,9 @@ Finished...
 
 ## Source code {#source_code}
 
-> **Tip** The full source code for the example [can be found on Github here](https://github.com/dronecore/DroneCore/tree/master/example/takeoff_land).
+> **Tip** The full source code for the example [can be found on Github here](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/example/takeoff_land).
 
-[CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/master/example/takeoff_land/CMakeLists.txt)
+[CMakeLists.txt](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/example/takeoff_land/CMakeLists.txt)
 
 ```make
 cmake_minimum_required(VERSION 2.8.12)
@@ -86,7 +86,7 @@ target_link_libraries(takeoff_and_land
 )
 ```
 
-[takeoff_and_land.cpp](https://github.com/dronecore/DroneCore/blob/master/example/takeoff_land/takeoff_and_land.cpp)
+[takeoff_and_land.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/example/takeoff_land/takeoff_and_land.cpp)
 ```cpp
 //
 // Simple example to demonstrate how to use DroneCore.

--- a/en/getting_started/faq.md
+++ b/en/getting_started/faq.md
@@ -28,7 +28,7 @@ libCURL will be required to download the camera definition file which is referen
 
 ### How are plugins added?
 
-Plugins need to have the correct structure and be placed in the [plugins directory](https://github.com/dronecore/DroneCore/tree/master/plugins). It is also possible to add external plugins which are outside of the DroneCore tree. For instructions see the [build docs](../contributing/build.md#build-with-external-directory-for-plugins-and-custom-integration_tests).
+Plugins need to have the correct structure and be placed in the [plugins directory](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/plugins). It is also possible to add external plugins which are outside of the DroneCore tree. For instructions see the [build docs](../contributing/build.md#build-with-external-directory-for-plugins-and-custom-integration_tests).
 
 ### Can a plugin depend on another one?
 

--- a/en/getting_started/faq.md
+++ b/en/getting_started/faq.md
@@ -28,7 +28,7 @@ libCURL will be required to download the camera definition file which is referen
 
 ### How are plugins added?
 
-Plugins need to have the correct structure and be placed in the [plugins directory](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/plugins). It is also possible to add external plugins which are outside of the DroneCore tree. For instructions see the [build docs](../contributing/build.md#build-with-external-directory-for-plugins-and-custom-integration_tests).
+Plugins need to have the correct structure and be placed in the [plugins directory](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/plugins). It is also possible to create [DroneCore Extensions](../guide/dronecore_extensions.md) that contain plugins outside of the DroneCore tree.
 
 ### Can a plugin depend on another one?
 

--- a/en/guide/dronecore_extensions.md
+++ b/en/guide/dronecore_extensions.md
@@ -32,7 +32,7 @@ A simplified view of a "typical" extension directory is shown below (in this cas
 
 ## Create a DroneCore Extension Library
 
-To create a new C++ DroneCore Extension Library, first copy [DroneCore/external_example](https://github.com/dronecore/DroneCore/tree/master/external_example) to the same folder level as the DroneCore directory.
+To create a new C++ DroneCore Extension Library, first copy [DroneCore/external_example](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/external_example) to the same folder level as the DroneCore directory.
 Then rename the top level folder as desired.
 
 The *external_example* contains a single integration test (**hello_world.cpp**) and a single plugin (**/example**) 
@@ -74,7 +74,7 @@ Tests in extension libraries are written and run exactly the same as "normal" Dr
 
 To build *DroneCore* so that it includes the extension library, specify the top level directory `EXTERNAL_DIR` in the `make` command 
 (only one external directory can be specified). 
-The line below shows how this is done for the [external_example](https://github.com/dronecore/DroneCore/tree/master/external_example) directory.
+The line below shows how this is done for the [external_example](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/external_example) directory.
 
 ```
 make clean  # This is required!

--- a/en/guide/missions.md
+++ b/en/guide/missions.md
@@ -201,6 +201,6 @@ At time of writing the Mission API does not provide takeoff, land or "return to 
 * [Mission Flight Mode](https://docs.px4.io/en/flight_modes/mission.html) (PX4 User Guide)
 * [Fly Mission](../examples/fly_mission.md) (DroneCore Example)
 * Integration tests:
-  * [mission.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/mission.cpp)
-  * [mission_change_speed.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/mission_change_speed.cpp)
-  * [mission_survey.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/mission_survey.cpp)
+  * [mission.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/mission.cpp)
+  * [mission_change_speed.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/mission_change_speed.cpp)
+  * [mission_survey.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/mission_survey.cpp)

--- a/en/guide/offboard.md
+++ b/en/guide/offboard.md
@@ -20,7 +20,7 @@ Device &device = dc.device();
 
 To use offboard mode you must first create a setpoint using either [set_velocity_ned()](../api_reference/classdronecore_1_1_offboard.md#classdronecore_1_1_offboard_1a9e7f369a8f7459dc7705f4453a8c307d) or [set_velocity_body()](../api_reference/classdronecore_1_1_offboard.md#classdronecore_1_1_offboard_1ad9dc585be1bc2dba699cf089d4c274cc). You can use any setpoint you like - the vehicle will start acting on the current setpoint as soon as the mode starts. 
 
-After you have created a setpoint call [start()](../api_reference/classdronecore_1_1_offboard.md#classdronecore_1_1_offboard_1a2b3aecd25645101a705cd1d80782311a) or [start_async()](../api_reference/classdronecore_1_1_offboard.md#classdronecore_1_1_offboard_1a5dd9d18eedb0e4a8f1bbbeebf6f99aa8) to switch to offboard mode. 
+After you have created a setpoint call [start()](../api_reference/classdronecore_1_1_offboard.md#classdronecore_1_1_offboard_1a658454f130f7b19d56f23347a448f1b9) or [start_async()](../api_reference/classdronecore_1_1_offboard.md#classdronecore_1_1_offboard_1a5dd9d18eedb0e4a8f1bbbeebf6f99aa8) to switch to offboard mode. 
 
 ```cpp
 // Create a setpoint before starting offboard mode (in this case a null setpoint)
@@ -39,7 +39,7 @@ Above we use the synchronous API, and then use [Offboard::result_str()](../api_r
 
 You can change the setpoints as needed (new setpoints replace any old setpoints).
 
-To stop offboard mode call [Offboard::stop()](../api_reference/classdronecore_1_1_offboard.md#classdronecore_1_1_offboard_1a2cecfbeb40bcd1d314fcfb07eb4dcd60) or [stop_async()](../api_reference/classdronecore_1_1_offboard.md#classdronecore_1_1_offboard_1afbe6f50f63d3bc43acc4dfc2f797ca0a). 
+To stop offboard mode call [Offboard::stop()](../api_reference/classdronecore_1_1_offboard.md#classdronecore_1_1_offboard_1ae223c08f1ffc694b26d847cab7738406) or [stop_async()](../api_reference/classdronecore_1_1_offboard.md#classdronecore_1_1_offboard_1afbe6f50f63d3bc43acc4dfc2f797ca0a). 
 DroneCore will then clear the current setpoint and put the vehicle into 
 [Hold flight mode](https://docs.px4.io/en/flight_modes/hold.html). 
 The synchronous API is used as shown below:

--- a/en/guide/offboard.md
+++ b/en/guide/offboard.md
@@ -188,6 +188,6 @@ Additional information/examples for the Offboard API are linked below:
 
 * [Example: Offboard Velocity](../examples/offboard_velocity.md)
 * Integration tests:
-  * [offboard_velocity.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/offboard_velocity.cpp)
+  * [offboard_velocity.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/offboard_velocity.cpp)
 
 

--- a/en/guide/taking_off_landing.md
+++ b/en/guide/taking_off_landing.md
@@ -207,7 +207,7 @@ Additional information/examples for the Action API are linked below:
 
 * [Example: Takeoff and Land](../examples/takeoff_and_land.md)
 * Integration tests:
-  * [simple_hover.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/simple_hover.cpp)
-  * [async_hover.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/async_hover.cpp)
-  * [takeoff_and_kill.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/takeoff_and_kill.cpp)
+  * [simple_hover.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/simple_hover.cpp)
+  * [async_hover.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/async_hover.cpp)
+  * [takeoff_and_kill.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/takeoff_and_kill.cpp)
 

--- a/en/guide/telemetry.md
+++ b/en/guide/telemetry.md
@@ -151,8 +151,8 @@ Additional information/examples for the Telemetry API are linked below:
 
 * [DroneCore Examples](../examples/README.md)
 * Integration tests:
-  * [telemetry_async.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/telemetry_async.cpp)
-  * [telemetry_health.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/telemetry_health.cpp)
-  * [telemetry_modes.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/telemetry_modes.cpp)
-  * [telemetry_simple.cpp](https://github.com/dronecore/DroneCore/blob/master/integration_tests/telemetry_simple.cpp)
+  * [telemetry_async.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/telemetry_async.cpp)
+  * [telemetry_health.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/telemetry_health.cpp)
+  * [telemetry_modes.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/telemetry_modes.cpp)
+  * [telemetry_simple.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/integration_tests/telemetry_simple.cpp)
 

--- a/en/guide/telemetry.md
+++ b/en/guide/telemetry.md
@@ -12,7 +12,7 @@ The `Telemetry` API provides methods to return the following types of informatio
 
 * [Position](../api_reference/structdronecore_1_1_telemetry_1_1_position.md) - latitude and longitude in degrees, and altitude relative to sea level and to the takeoff altitude.
 * [Battery](../api_reference/structdronecore_1_1_telemetry_1_1_battery.md) - voltage and percentage power remaining.
-* [GroundSpeedNED](http://localhost:4000/en/api_reference/structdronecore_1_1_telemetry_1_1_ground_speed_n_e_d.md) - velocity components in NED coordinates.
+* [GroundSpeedNED](../api_reference/structdronecore_1_1_telemetry_1_1_ground_speed_n_e_d.md) - velocity components in NED coordinates.
 * Vehicle attitude/orientation - as a [Quaternion](../api_reference/structdronecore_1_1_telemetry_1_1_quaternion.md) or [EulerAngle](../api_reference/structdronecore_1_1_telemetry_1_1_euler_angle.md)
 * [GPSInfo](../api_reference/structdronecore_1_1_telemetry_1_1_g_p_s_info.md) - type of fix, if any, and number of satellites.
 * [Health](../api_reference/structdronecore_1_1_telemetry_1_1_health.md) - calibration status of various sensors and confirmation that position estimates are good enough for position control.


### PR DESCRIPTION
This updates docs to:
1. Fix links from travis broken link checker. 
2. Update links to github to be relative to a variable defined in the book.json. This will allow us to point to different docs on master and develop. May need more rework, but aim is to properly support versions of dronecore source for examples and source links.