### PR TITLE
First draft of updates for #51

### DIFF
--- a/en/contributing/build.md
+++ b/en/contributing/build.md
@@ -92,7 +92,7 @@ To build the *DroneCore* C++ Library on Windows:
 
 ## Install DroneCore {#install-artifacts}
 
-*Installing* builds DroneCore **and** copies the libraries and header files into a "public" location so that they can be referenced by C++ applications (see [Building C++ Apps](../guide/toolchain.md)). DroneCore supports installation system-wide (recommended) or locally within the DroneCore tree.
+*Installing* builds DroneCore **and** copies the libraries and header files into a "public" location so that they can be referenced by C++ applications (see [Building C++ Apps](../guide/toolchain.md)). DroneCore supports installation system-wide by default. You can also install files locally/relative to the DroneCore tree if needed.
 
 > **Warning** System-wide installation is not yet supported on Windows (see [#155](https://github.com/dronecore/DroneCore/issues/155)) so you will need to [install DroneCore locally](#dronecore_local_install).
 >
@@ -109,10 +109,15 @@ To install DroneCore system-wide:
 ```sh
 make clean  #REQUIRED!
 make default
-sudo default install
+sudo make default install  #sudo required to install files to system directories!
 ```
 
-> **Tip** The `sudo` command is required (above) in order to install files to system directories.
+> **Tip** The first time you build DroneCore you may also need to [update the linker cache](http://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html). 
+> On Ubuntu call the following:
+  ```
+  sudo ldconfig
+  ```
+
 
 ### Local Install {#dronecore_local_install}
 

--- a/en/contributing/build.md
+++ b/en/contributing/build.md
@@ -107,11 +107,12 @@ System-wide installation copies DroneCore to the standard system-wide locations 
 To install DroneCore system-wide:
 
 ```sh
-sudo make clean  #REQUIRED!
+make clean  #REQUIRED!
+make default
 sudo default install
 ```
 
-> **Tip** The `sudo` command is required (above) in order to copy or remove files in system directories.
+> **Tip** The `sudo` command is required (above) in order to install files to system directories.
 
 ### Local Install {#dronecore_local_install}
 
@@ -255,7 +256,8 @@ DroneCore can be extended with plugins and integration tests that are defined "o
 
 The commands to build and install DroneCore with an extension library are:
 ```
-sudo make clean   # This is required!
-sudo make EXTERNAL_DIR=relative_path_to_external_directory default install
+make clean   # This is required!
+make default EXTERNAL_DIR=relative_path_to_external_directory
+sudo make default install
 ```
 See [DroneCore Extensions](../guide/dronecore_extensions.md) for more information.

--- a/en/contributing/build.md
+++ b/en/contributing/build.md
@@ -1,8 +1,13 @@
 # Building DroneCore from Source
 
-To build all of DroneCore from source you will first need to build the C++ library, and then any wrappers. The instructions below show how.
+This section explains how to [build](#build_dronecore_cpp) and [install](#install-artifacts) the DroneCore C++ library from source (both "natively" and in docker) for all our target platforms. It also shows how to build DroneCore with extensions and build the API Reference documentation. 
 
-## Build the C++ Library
+
+## Build the C++ Library {#build_dronecore_cpp}
+
+This section explains how to build the DroneCore C++ library from source, 
+along with its unit and integration tests. 
+Build artifacts are created in the **build** subdirectory.
 
 ### macOS {#mac-os-x}
 
@@ -43,7 +48,7 @@ To build the *DroneCore* C++ Library on Linux (or macOS after installing the [pr
      BUILD_TYPE=Release make
      ```
 
-1. (Optionally) "Install" DroneCore [as described below](#install-artifacts). This is required in order to build DroneCore applications, but not to run DroneCore test code.
+1. (Optionally) "Install" DroneCore [as described below](#install-artifacts). This is required in order to build [DroneCore C++ apps](../guide/toolchain.md), but not to run DroneCore test code.
    
 1. (Optionally) Build the API Reference documentation by calling:
    ```sh
@@ -82,48 +87,49 @@ To build the *DroneCore* C++ Library on Windows:
      cmake --build . --config Release
      ```
 
-1. (Optionally) "Install" DroneCore [as described below](#install-artifacts). This is required in order to build DroneCore applications, but not to run DroneCore test code.
+1. (Optionally) "Install" DroneCore [as described below](#install-artifacts). This is required in order to build [Dronecore C++ apps](../guide/toolchain.md), but not to run DroneCore test code.
 
 
 ## Install DroneCore {#install-artifacts}
 
-In order to *use* DroneCore your C++ applications need to be able locate the DroneCore libraries and header files (see [Building C++ Apps](../guide/toolchain.md)). You can either install these to standard system locations or locally within the DroneCore directory.
+*Installing* builds DroneCore **and** copies the libraries and header files into a "public" location so that they can be referenced by C++ applications (see [Building C++ Apps](../guide/toolchain.md)). DroneCore supports installation system-wide (recommended) or locally within the DroneCore tree.
 
-> **Tip** The example code assumes that DroneCore is installed locally. The example **CMakeLists.txt** file can easily be modified to find the system-wide installation.
+> **Warning** System-wide installation is not yet supported on Windows (see [#155](https://github.com/dronecore/DroneCore/issues/155)) so you will need to [install DroneCore locally](#dronecore_local_install).
+>
+> Windows gurus, we'd [love your help](../README.md#getting-help) to implement this).
 
+### System-wide Install {#dronecore_system_wide_install}
 
-### System-wide Install
+System-wide installation copies DroneCore to the standard system-wide locations for your platform (On Ubuntu Linux this is **/usr/local/**).
 
-Installing DroneCore system-wide means that the files you need to build your apps are always in the same place, and your build definition files can be simpler because they do not need to consider relative locations.
+> **Warning** System-wide installation overwrites any previously installed version of DroneCore. 
 
-> **Warning** System-wide install is not (yet) supported on Windows. If you're a Windows guru, we'd [love your help](../README.md#getting-help) to set this up.
+To install DroneCore system-wide:
 
-To install the files system-wide:
+```sh
+sudo make clean  #REQUIRED!
+sudo default install
+```
+
+> **Tip** The `sudo` command is required (above) in order to copy or remove files in system directories.
+
+### Local Install {#dronecore_local_install}
+
+Local installation copies DroneCore headers/library to a user-specified location in the DroneCore directory.
+
+On Linux/macOS use the `INSTALL_PREFIX` variable to specify a path relative to the **DroneCore/build/** folder
+(or an absolute path).
+For example, to install into the **DroneCore/install/** folder you would call:
 
 ```sh
 make clean  #REQUIRED!
-sudo INSTALL_PREFIX=/usr/local make default install
-```
-
-> **Note** System-wide install overwrites standard install locations. If you already have DroneCore installed through some other mechanism it will be replaced!
-
-### Local Install
-
-On Linux/macOS the DroneCore headers and static library can be installed locally into the folder **DroneCore/install/** using:
-
-```sh
-make default install
+INSTALL_PREFIX=../../install make default install
 ```
 
 On Windows specify `--target install` when building, as shown:
 ```sh
 cmake --build . --target install
 ```
-
-
-### Using the Compiled C++ Library
-
-The [Building C++ Apps](../guide/toolchain.md) topic explains how use the library in C++ apps.
 
 
 ## Build for Android
@@ -142,14 +148,14 @@ Also, you need to set these three environment variables:
 
 E.g. you can add the lines below to your .bashrc, (or .zshrc for zshell users, or .profile):
 
-```
+```sh
 export NDK_ROOT=$HOME/Android/android-ndk-r13
 export ANDROID_TOOLCHAIN_CMAKE=$HOME/Android/android-ndk-r13/build/cmake/android.toolchain.cmake
 export ANDROID_CMAKE_BIN=$HOME/Android/Sdk/cmake/3.6.3155560/bin/cmake
 ```
 
 Then you build for all Android architectures:
-```
+```sh
 make android install
 ```
 
@@ -160,13 +166,13 @@ make android install
 
 To build for real iOS devices on macOS:
 
-```
+```sh
 make ios install
 ```
 
 Build for the iOS simulator on macOS:
 
-```
+```sh
 make ios_simulator install
 ```
 
@@ -245,9 +251,11 @@ You can also build the image yourself using the [Dockerfile](https://github.com/
 
 ## Build DroneCore Extensions {#dronecore_extensions}
 
-DroneCore can be extended with plugins and integration tests that are defined "out of tree". These are declared inside a parallel directory that is included into the DroneCore at compile time (by specifying `EXTERNAL_DIR` in the `make` command):
+DroneCore can be extended with plugins and integration tests that are defined "out of tree". These are declared inside a parallel directory that is included into the DroneCore at compile time (by specifying `EXTERNAL_DIR` in the `make` command).
+
+The commands to build and install DroneCore with an extension library are:
 ```
-make clean   # This is required!
-make EXTERNAL_DIR=relative_path_to_external_directory
+sudo make clean   # This is required!
+sudo make EXTERNAL_DIR=relative_path_to_external_directory default install
 ```
 See [DroneCore Extensions](../guide/dronecore_extensions.md) for more information.

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -89,3 +89,20 @@ On all platform you can then run the new executable (from the **\build** directo
 > is specified in the **CMakeLists.txt** file as the first value in the call to `add_executable()`.
 
 If you have already started the simulation the example code should connect to PX4, and you will be able to observe behaviour through the DroneCore terminal, SITL terminal, and/or *QGroundControl*.
+
+## Troubleshooting
+
+### Linux: Error loading shared libraries
+
+The following error is raised when you run an application/example on Linux and the DroneCore shared library cannot be found:
+
+```
+error while loading shared libraries: libdronecore.so: cannot open shared object file: No such file or directory
+```
+
+The solution is to update the linker cache so that the system can find the library. On Ubuntu call the following:
+```
+sudo ldconfig
+```
+
+For more information/other Linux flavours see [Linux Documentation > Shared Libraries](http://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html).

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -45,13 +45,12 @@ To build the examples follow the instructions below, replacing *takeoff_and_land
 
 #### Linux
 
-First [Build and install the DroneCore C++ Library](../contributing/build.md).
-Make sure that you install the library and headers locally (rather than system-wide) using the command below:
+First [Build and install the DroneCore C++ Library](../contributing/build.md) using the command below:
 ```sh
-make default install
+sudo make default install
 ```
 
-Then build and run the example:
+Then build the example:
 ```sh
 cd example/takeoff_and_land/
 mkdir build && cd build
@@ -62,13 +61,13 @@ make
 #### Windows
 
 First [Build and install the DroneCore C++ Library](../contributing/build.md).
-Make sure that you install the library and headers in the standard location:
+Make sure that you install the library and headers in the standard location: 
 
 ```sh
 cmake --build . --target install
 ```
 
-Build and run the example as shown below (in this case *takeoff_and_land*, but all the other examples are built and run in the same way):
+Build the example as shown below (in this case *takeoff_and_land*, but all the other examples are built in the same way):
 ```sh
 cd example/takeoff_land/
 mkdir build && cd build
@@ -83,5 +82,8 @@ On all platform you can then run the new executable (from the **\build** directo
 ```sh
 ./takeoff_and_land
 ```
+
+> **Tip** Most examples will create a binary with the same name as the example. The name that is used
+> is specified in the **CMakeLists.txt** file as the first value in the call to `add_executable()`.
 
 If you have already started the simulation the example code should connect to PX4, and you will be able to observe behaviour through the DroneCore terminal, SITL terminal, and/or *QGroundControl*.

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -47,6 +47,8 @@ To build the examples follow the instructions below, replacing *takeoff_and_land
 
 First [Build and install the DroneCore C++ Library](../contributing/build.md) using the command below:
 ```sh
+make clean
+made default
 sudo make default install
 ```
 

--- a/en/examples/fly_mission.md
+++ b/en/examples/fly_mission.md
@@ -7,15 +7,18 @@ This example shows how to create, upload, and run, pause, and restart missions u
 
 ## Running the Example {#run_example}
 
-The example is built and run [as described here](/examples/README.md#trying_the_examples) (the standard way). 
+The example is built and run [as described here](../examples/README.md#trying_the_examples) (the standard way). 
 
 The example terminal output should be similar to that shown below:
 
-> **Note** This is for a release build of DroneCore. A debug build will display additional information from DroneCore.
+> **Note** This is from a debug build of DroneCore. A release build will omit the "Debug" messages.
 
 ```
 $ ./fly_mission 
 Waiting to discover device...
+[03:42:51|Info ] New device on: 127.0.0.1:14557 (udp_connection.cpp:210)
+[03:42:51|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2017-11-14/2 (device_impl.cpp:225)
+[03:42:51|Debug] Discovered 4294967298 (dronecore_impl.cpp:234)
 Discovered device with UUID: 4294967298
 Waiting for device to be ready
 ...
@@ -23,11 +26,39 @@ Waiting for device to be ready
 Device ready
 Creating and uploading mission
 Uploading mission...
+[03:43:07|Debug] Send mission item 0 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 1 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 2 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 3 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 4 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 5 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 6 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 7 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 8 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 9 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 10 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 11 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 12 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 13 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 14 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 15 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 16 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 17 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 18 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 19 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 20 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 21 (mission_impl.cpp:712)
+[03:43:07|Debug] Send mission item 22 (mission_impl.cpp:712)
+[03:43:07|Info ] Mission accepted (mission_impl.cpp:136)
 Mission uploaded.
 Arming...
+[03:43:07|Debug] MAVLink: info: ARMED by arm/disarm component command (device_impl.cpp:225)
 Armed.
 Starting mission.
 Started mission.
+[03:43:07|Debug] MAVLink: info: Executing mission. (device_impl.cpp:225)
+[03:43:07|Debug] MAVLink: info: Takeoff to 10.0 meters above home. (device_impl.cpp:225)
+[03:43:07|Debug] MAVLink: info: Takeoff detected (device_impl.cpp:225)
 Mission status update: 0 / 6
 Mission status update: 0 / 6
 Mission status update: 1 / 6
@@ -53,12 +84,19 @@ Mission status update: 4 / 6
 Mission status update: 5 / 6
 Mission status update: 5 / 6
 Mission status update: 5 / 6
+Mission status update: 5 / 6
+[03:44:10|Debug] MAVLink: info: Mission finished, loitering. (device_impl.cpp:225)
 Mission status update: 6 / 6
 Commanding RTL...
 Commanded RTL.
+[03:44:10|Debug] MAVLink: info: RTL: return at 498 m (10 m above home) (device_impl.cpp:225)
+[03:44:18|Debug] MAVLink: info: RTL: descend to 493 m (5 m above home) (device_impl.cpp:225)
+[03:44:22|Debug] MAVLink: info: RTL: loiter 5.0s (device_impl.cpp:225)
+[03:44:27|Debug] MAVLink: info: RTL: land at home (device_impl.cpp:225)
+[03:44:40|Debug] MAVLink: info: Landing detected (device_impl.cpp:225)
+[03:44:43|Debug] MAVLink: info: DISARMED by auto disarm on land (device_impl.cpp:225)
 Mission status update: 6 / 6
 Disarmed, exiting.
-...
 ```
 
 ## How it works

--- a/en/examples/fly_mission.md
+++ b/en/examples/fly_mission.md
@@ -81,36 +81,14 @@ if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
     add_definitions("-std=c++11 -WX -W2")
-    set(platform_libs "Ws2_32.lib")
 endif()
-
-# Add DEBUG define for Debug target
-set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
-
-# This finds thread libs on Linux, Mac, and Windows.
-find_package(Threads REQUIRED)
-
-# Not needed if DroneCore installed system-wide
-include_directories(
-    ${CMAKE_SOURCE_DIR}/../../install/include
-)
 
 add_executable(fly_mission
     fly_mission.cpp
 )
 
-# Not needed if DroneCore installed system-wide
-if(WINDOWS)
-    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
-else()
-    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a")
-endif()
-
 target_link_libraries(fly_mission
-    ${dronecore_lib}  # Remove/comment out this line if DroneCore used locally
-    # dronecore  # Uncomment/add this line if DroneCore installed system-wide
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${platform_libs}
+    dronecore
 )
 ```
 
@@ -205,7 +183,7 @@ int main(int /*argc*/, char ** /*argv*/)
     mission_items.push_back(
         add_mission_item(47.398139363821485, 8.5453846156597137,
                          10.0f, 5.0f, true,
-                         -46.0f, 0.0f,
+                         -45.0f, 0.0f,
                          MissionItem::CameraAction::START_VIDEO));
 
     mission_items.push_back(

--- a/en/examples/offboard_velocity.md
+++ b/en/examples/offboard_velocity.md
@@ -68,36 +68,14 @@ if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
     add_definitions("-std=c++11 -WX -W2")
-    set(platform_libs "Ws2_32.lib")
 endif()
-
-# Add DEBUG define for Debug target
-set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
-
-# This finds thread libs on Linux, Mac, and Windows.
-find_package(Threads REQUIRED)
-
-# Not needed if DroneCore installed system-wide
-include_directories(
-    ${CMAKE_SOURCE_DIR}/../../install/include
-)
 
 add_executable(offboard
     offboard_velocity.cpp
 )
 
-# Not needed if DroneCore installed system-wide
-if(WINDOWS)
-    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
-else()
-    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a")
-endif()
-
 target_link_libraries(offboard
-    ${dronecore_lib}  # Remove/comment out this line if DroneCore used locally
-    # dronecore  # Uncomment/add this line if DroneCore installed system-wide
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${platform_libs}
+    dronecore
 )
 ```
 

--- a/en/examples/offboard_velocity.md
+++ b/en/examples/offboard_velocity.md
@@ -7,32 +7,34 @@ This example shows how to how to control a vehicle in *Offboard mode* using velo
 
 ## Running the Example {#run_example}
 
-The example is built and run [as described here](/examples/README.md#trying_the_examples) (the standard way). 
+The example is built and run [as described here](../examples/README.md#trying_the_examples) (the standard way). 
 
 The example terminal output should be similar to that shown below:
 
-> **Note** This is for a debug build of DroneCore.
+> **Note** This is from a debug build of DroneCore. A release build will omit the "Debug" messages.
 
 ```
 $ ./offboard 
+ubuntu@ubuntu:~/DroneCore/example/offboard_velocity/build$ ./offboard 
 Wait for device to connect via heartbeat
-[05:58:02|Info ] New device on: 127.0.0.1:14557 (udp_connection.cpp:210)
-[05:58:02|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2017-10-31/0 (device_impl.cpp:223)
-[05:58:03|Debug] Discovered 4294967298 (dronecore_impl.cpp:234)
+[03:48:52|Info ] New device on: 127.0.0.1:14557 (udp_connection.cpp:210)
+[03:48:52|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2017-11-14/2 (device_impl.cpp:225)
+[03:48:53|Debug] Discovered 4294967298 (dronecore_impl.cpp:234)
+Waiting for device to be ready
+...
 Waiting for device to be ready
 Device is ready
-[05:58:04|Debug] MAVLink: info: ARMED by arm/disarm component command (device_impl.cpp:223)
 Armed
+[03:49:07|Debug] MAVLink: info: ARMED by arm/disarm component command (device_impl.cpp:225)
 In Air...
-[05:58:04|Debug] MAVLink: info: Using minimum takeoff altitude: 2.50 m (device_impl.cpp:223)
-[05:58:04|Debug] MAVLink: info: Takeoff detected (device_impl.cpp:223)
-[05:58:04|Debug] MAVLink: critical: Using minimum takeoff altitude: 2.50 m (device_impl.cpp:223)
+[03:49:07|Debug] MAVLink: info: Using minimum takeoff altitude: 2.50 m (device_impl.cpp:225)
+[03:49:07|Debug] MAVLink: info: Takeoff detected (device_impl.cpp:225)
+[03:49:07|Debug] MAVLink: critical: Using minimum takeoff altitude: 2.50 m (device_impl.cpp:225)
 [NED] Offboard started
 [NED] Turn to face East
 [NED] Go North and back South
 [NED] Turn to face West
 [NED] Go up 2 m/s, turn to face South
-[05:58:26|Debug] MAVLink: emergency: Accel #1 fail:  TOUT! (device_impl.cpp:223)
 [NED] Go down 1 m/s, turn to face North
 [NED] Offboard stopped
 [BODY] Offboard started
@@ -44,7 +46,7 @@ In Air...
 [BODY] Fly a circle sideways
 [BODY] Wait for a bit
 [BODY] Offboard stopped
-[05:59:28|Debug] MAVLink: info: Landing at current position (device_impl.cpp:223)
+[03:50:31|Debug] MAVLink: info: Landing at current position (device_impl.cpp:225)
 Landed
 ```
 

--- a/en/examples/takeoff_and_land.md
+++ b/en/examples/takeoff_and_land.md
@@ -53,36 +53,14 @@ if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
     add_definitions("-std=c++11 -WX -W2")
-    set(platform_libs "Ws2_32.lib")
 endif()
-
-# Add DEBUG define for Debug target
-set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
-
-# This finds thread libs on Linux, Mac, and Windows.
-find_package(Threads REQUIRED)
-
-# Not needed if DroneCore installed system-wide
-include_directories(
-    ${CMAKE_SOURCE_DIR}/../../install/include
-)
 
 add_executable(takeoff_and_land
     takeoff_and_land.cpp
 )
 
-# Not needed if DroneCore installed system-wide
-if(WINDOWS)
-    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
-else()
-    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a")
-endif()
-
 target_link_libraries(takeoff_and_land
-    ${dronecore_lib}  # Remove/comment out this line if DroneCore used locally
-    # dronecore  # Uncomment/add this line if DroneCore installed system-wide
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${platform_libs}
+    dronecore
 )
 ```
 

--- a/en/examples/takeoff_and_land.md
+++ b/en/examples/takeoff_and_land.md
@@ -8,32 +8,41 @@ It sets up a UDP connection, waits for a device to appear, arms it, and commands
 
 ## Running the Example {#run_example}
 
-The example is built and run [as described here](/examples/README.md#trying_the_examples) (the standard way).
+The example is built and run [as described here](../examples/README.md#trying_the_examples) (the standard way).
 
-The example terminal output is:
+The example terminal output should be similar to that shown below:
+
+> **Note** This is from a debug build of DroneCore. A release build will omit the "Debug" messages.
+
 ```sh
 $ ./takeoff_and_land 
 Waiting to discover device...
-Partner IP: 127.0.0.1:14557
+[03:34:57|Info ] New device on: 127.0.0.1:14557 (udp_connection.cpp:210)
+[03:34:57|Debug] Discovered 4294967298 (dronecore_impl.cpp:234)
 Discovered device with UUID: 4294967298
 Arming...
 Taking off...
-Altitude: -0.042 m
-Altitude: 0.054 m
-Altitude: 0.989 m
-Altitude: 2.128 m
-Altitude: 2.434 m
-Altitude: 2.446 m
-Altitude: 2.408 m
-Altitude: 2.377 m
-Altitude: 2.369 m
-Altitude: 2.374 m
+[03:34:59|Debug] MAVLink: info: ARMED by arm/disarm component command (device_impl.cpp:225)
+[03:34:59|Debug] MAVLink: info: Using minimum takeoff altitude: 2.50 m (device_impl.cpp:225)
+[03:34:59|Debug] MAVLink: info: Takeoff detected (device_impl.cpp:225)
+[03:34:59|Debug] MAVLink: critical: Using minimum takeoff altitude: 2.50 m (device_impl.cpp:225)
+Altitude: 0 m
+Altitude: 1.381 m
+Altitude: 2.283 m
+Altitude: 2.519 m
+Altitude: 2.55 m
+Altitude: 2.53 m
+Altitude: 2.508 m
+Altitude: 2.491 m
+Altitude: 2.479 m
+Altitude: 2.471 m
 Landing...
-Altitude: 1.758 m
-Altitude: 0.782 m
-Altitude: -0.068 m
-Altitude: -0.441 m
-Altitude: -0.573 m
+[03:35:09|Debug] MAVLink: info: Landing at current position (device_impl.cpp:225)
+Altitude: 2.321 m
+Altitude: 1.587 m
+Altitude: 0.813 m
+Altitude: 0.025 m
+Altitude: -0.483 m
 Finished...
 ```
 

--- a/en/guide/dronecore_extensions.md
+++ b/en/guide/dronecore_extensions.md
@@ -74,19 +74,16 @@ Tests in extension libraries are written and run exactly the same as "normal" Dr
 
 To build *DroneCore* so that it includes the extension library, specify the top level directory `EXTERNAL_DIR` in the `make` command 
 (only one external directory can be specified). 
-The line below shows how this is done for the [external_example](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/external_example) directory.
 
-```
-make clean  # This is required!
-make EXTERNAL_DIR=external_example
-```
-
-To build a parallel *DroneCore_Extensions* folder (from within the DroneCore directory) you would enter:
+To build and install a parallel *DroneCore_Extensions* folder (from within the DroneCore directory) you would enter:
 
 ```
 make clean   # This is required!
-make EXTERNAL_DIR=../DroneCore_Extensions
+make default EXTERNAL_DIR=../DroneCore_Extensions
+sudo make default install   # sudo needed to install files into system directories. 
 ```
+
+> **Tip** You can test this by copying the [DroneCore/external_example](https://github.com/dronecore/DroneCore/tree/{{ book.github_branch }}/external_example) directory as a peer of **DroneCore** and renaming it to *DroneCore_Extensions*.
 
 
 <!-- 

--- a/en/guide/toolchain.md
+++ b/en/guide/toolchain.md
@@ -58,9 +58,11 @@ target_link_libraries(your_executable_name
 
 > **Tip** Where possible install Dronecore [system wide](../contributing/build.md#dronecore_system_wide_install) and follow the instructions in the [previous section](#dronecore_installed_system). 
 
-**CMakeLists.txt** is more complicated when DroneCore is [installed locally](../contributing/build.md#dronecore_local_install), because you need to specify where the build should find both headers and library files. The example file below assumes that DroneCore was installed locally into the directory **/install/**.
+**CMakeLists.txt** is more complicated when DroneCore is [installed locally](../contributing/build.md#dronecore_local_install), because you need to specify where the build should find both headers and library files *relative to your current directory*. 
 
-The new lines are marked up using `# >>> ADDED` comments below.  You have to change the same information as before: *your_project_name*, *your_executable_name* and *your_source_file*. You may also need to change the location of the headers/library files, depending on where your application is hosted relative to the **DroneCore** project root directory (this example assumes that your application is nested two levels deep, just like our example code).
+The changes to the file (with respect to the previous version) are shown below.  You have to change the same information as before: *your_project_name*, *your_executable_name* and *your_source_file*. 
+
+> **Note** The example file below assumes that DroneCore was installed locally into the directory **DroneCore/install/** and that the application is nested two levels deep (at the same level as the DroneCore example code).
 
 ```cmake
 cmake_minimum_required(VERSION 2.8.12)
@@ -75,38 +77,38 @@ else()
     add_definitions("-std=c++11 -WX -W2")
 endif()
 
-# >>> 
-# Specify include directories
-include_directories(
-    # Not needed if installed system-wide
-    ${CMAKE_SOURCE_DIR}/../../install/include
-)
-# >>>
-
 # Specify your app's executable name, and list of source files used to create it.
 add_executable(your_executable_name
     your_source_file.cpp
     # ... any other source files
 )
+```
+Remove/comment this section (Not using "system wide" DroneCore)
+```cmake
+#target_link_libraries(your_executable_name
+#    dronecore  #All apps link against dronecore library
+    # ... any other linked libraries
+#)
+```
+Add section specifying local path to include directories and DroneCore library.
+```cmake
+# Specify include directories
+include_directories(
+    ${CMAKE_SOURCE_DIR}/../../install/include
+)
 
-# >>> ADDED
 # Specify variable 'dronecore_lib' containing location of DroneCore library.
-if(WINDOWS)
+if(MSVC)
     set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
 else()
     set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.so")
 endif()
-# <<< 
 
 # Specify your app's executable name and a list of linked libraries
 target_link_libraries(your_executable_name
-    # dronecore #Note, this is now commented out or removed
-    
-# >>> ADDED
     # Add  'dronecore_lib' variable defining where the DroneCore library can be found. 
     ${dronecore_lib}
     # dronecore # Link against library named dronecore in standard install location
-# <<< 
     # ... any other linked libraries
 )
 ```

--- a/en/guide/toolchain.md
+++ b/en/guide/toolchain.md
@@ -1,10 +1,10 @@
 # Building C++ DroneCore Apps
 
-DroneCore C++ apps are written in standard C++ (c++11) and can be built using your preferred build system, compiler and linker toolchain. The only requirements are:
-- The build system must be able to locate the DroneCore headers and libraries (installed as described [here](../contributing/build.md#install-artifacts)).
-- When using DroneCore you need to link to a thread library (e.g. *pthread* on a POSIX system). 
+DroneCore C++ apps are written in standard C++ (c++11) and can be built using your preferred build system, compiler and linker toolchain. 
+The only requirement is that the build system must be able to locate the DroneCore headers and libraries (installed as described [here](../contributing/build.md#install-artifacts)).
 
-DroneCore itself uses the [cmake](https://cmake.org/) build system, and we recommend that you do too. CMake is an open-source, cross-platform toolchain that allows you to build your examples on macOS, Linux and Windows using the same build file definition.
+DroneCore itself uses the [cmake](https://cmake.org/) build system, and we recommend that you do too. 
+*CMake* is an open-source, cross-platform toolchain that allows you to build your examples on macOS, Linux and Windows using the same build file definition.
 
 Below we explain how to set up a minimal build setup (**CMakeLists.txt**) file for your application.
 
@@ -13,85 +13,80 @@ Below we explain how to set up a minimal build setup (**CMakeLists.txt**) file f
 
 *Cmake* uses a definition file named **CMakeLists.txt** to define the project. This specifies the name of the project, compiler flags for different platforms and targets, where to find dependencies (libraries and header files), source files to build, and the name of the generated binary. **CMakeLists.txt** is typically stored in the root directory of your app project.
 
-The sections below show how you can set up the file for when DroneCore is installed system-wide or locally.
+The sections below show how you can set up the file for when DroneCore is [installed system wide](../contributing/build.md#dronecore_system_wide_install) (the default) or [locally](../contributing/build.md#dronecore_local_install).
+
+> **Warning** DroneCore system-wide installation is not yet supported on Windows (see [#155](https://github.com/dronecore/DroneCore/issues/155)). Instead build the app using a [local DroneCore installation](#dronecore_installed_locally). 
+>
+> Windows gurus, we'd [love your help](../README.md#getting-help) to implement this). 
 
 
-### DroneCore Installed System-wide
+### DroneCore Installed System-wide {#dronecore_installed_system}
 
-> **Warning** System-wide install is not (yet) supported on Windows (if you're a Windows guru, we'd [love your help](../README.md#getting-help) to implement this). You will have to use install locally as shown in the following section. 
-
-A "template" **CMakeLists.txt** is shown below. Almost all of the above file is boilerplate - the only things you need to change are *your_project_name*, *your_executable_name* and *your_source_file*. 
+A "template" **CMakeLists.txt** is shown below. Most of file is boilerplate - the only things you need to change are *your_project_name*, *your_executable_name* and *your_source_file*. 
 
 ```cmake
 cmake_minimum_required(VERSION 2.8.12)
+
+## Specify your project's name
 project(your_project_name)
 
-# Add platform/compiler specific flags
+# Enable strict handling of warnings
 if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
     add_definitions("-std=c++11 -WX -W2")
-    set(platform_libs "Ws2_32.lib")
 endif()
 
-# Add DEBUG define for Debug target
-set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
-
-# This finds thread libs on Linux, Mac, and Windows.
-find_package(Threads REQUIRED)
-
-# Specify your binary name, and list of source files used to create it.
+# Specify your app's executable name, and list of source files used to create it.
 add_executable(your_executable_name
     your_source_file.cpp
+    # ... any other source files
 )
 
+# Specify your app's executable name and a list of linked libraries
 target_link_libraries(your_executable_name
-    dronecore  # Link against library named dronecore in standard install location
-    ${CMAKE_THREAD_LIBS_INIT}  # Link against thread library found using find_package() 
-    ${platform_libs}  # Variable containing all libraries that to link against for this platform (e.g. pthread).
+    dronecore  #All apps link against dronecore library
+    # ... any other linked libraries
 )
 ```
 
-> **Tip** The make file can be so minimal because the `target_link_libraries()` function has the `dronecore` line, which tells *cmake* that DroneCore's library and headers are in the standard location.
+> **Note** The file format and required modifications are self-explanatory. 
+> If additional information is required see the [cmake documentation](https://cmake.org/cmake/help/latest/manual/cmake-commands.7.html).
 
-We'll explain some of it in the next section.
 
+### DroneCore Installed Locally {#dronecore_local_install}
 
-### DroneCore Installed Locally
+> **Tip** Where possible install Dronecore [system wide](../contributing/build.md#dronecore_system_wide_install) and follow the instructions in the [previous section](#dronecore_installed_system). 
 
-The **CMakeLists.txt** is more complicated when DroneCore is installed locally, because you need to specify where the build should find both headers and library files. 
+**CMakeLists.txt** is more complicated when DroneCore is [installed locally](../contributing/build.md#dronecore_local_install), because you need to specify where the build should find both headers and library files. The example file below assumes that DroneCore was installed locally into the directory **/install/**.
 
 The new lines are marked up using `# >>> ADDED` comments below.  You have to change the same information as before: *your_project_name*, *your_executable_name* and *your_source_file*. You may also need to change the location of the headers/library files, depending on where your application is hosted relative to the **DroneCore** project root directory (this example assumes that your application is nested two levels deep, just like our example code).
 
 ```cmake
 cmake_minimum_required(VERSION 2.8.12)
+
+## Specify your project's name
 project(your_project_name)
 
-# Add platform/compiler specific flags
+# Enable strict handling of warnings
 if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
     add_definitions("-std=c++11 -WX -W2")
-    set(platform_libs "Ws2_32.lib")
 endif()
 
-# Add DEBUG define for Debug target
-set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
-
-# This finds thread libs on Linux, Mac, and Windows.
-find_package(Threads REQUIRED)
-
-# >>> ADDED
+# >>> 
 # Specify include directories
 include_directories(
     # Not needed if installed system-wide
     ${CMAKE_SOURCE_DIR}/../../install/include
 )
-# <<< 
+# >>>
 
-# Specify your binary name, and list of source files used to create it.
+# Specify your app's executable name, and list of source files used to create it.
 add_executable(your_executable_name
     your_source_file.cpp
+    # ... any other source files
 )
 
 # >>> ADDED
@@ -99,78 +94,20 @@ add_executable(your_executable_name
 if(WINDOWS)
     set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
 else()
-    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a")
+    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.so")
 endif()
 # <<< 
 
+# Specify your app's executable name and a list of linked libraries
 target_link_libraries(your_executable_name
+    # dronecore #Note, this is now commented out or removed
+    
 # >>> ADDED
-    # Add  'dronecore_lib' variable defining where the dronecore library can be found. 
+    # Add  'dronecore_lib' variable defining where the DroneCore library can be found. 
     ${dronecore_lib}
     # dronecore # Link against library named dronecore in standard install location
 # <<< 
-    ${CMAKE_THREAD_LIBS_INIT}  # Link against thread library found using find_package() 
-    ${platform_libs}  # Variable containing all libraries that to link against for this platform (e.g. pthread).
-)
-```
-
-
-The main elements of the file are described below:
-
-1. The first two lines of the file should specify the minimum compatible version of *cmake* and *your* project's name.
-   ```cmake
-   cmake_minimum_required(VERSION 2.8.12)
-   project(your_project_name)
-   ```
-1. The [add_definitions()](https://cmake.org/cmake/help/latest/command/add_definitions.html) and [set()](https://cmake.org/cmake/help/latest/command/set.html) are used to the define flags that are used in compilation on different platforms. In this case we enable strict handling of warnings and an MSVC specific library.
-   ```cmake
-   if(NOT MSVC)
-       add_definitions("-std=c++11 -Wall -Wextra -Werror")
-   else()
-       add_definitions("-std=c++11 -WX -W2")
-       set(platform_libs "Ws2_32.lib")
-   endif()
-
-   # Add DEBUG define for Debug target
-   set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
-   ```
-1. The [find_package()](https://cmake.org/cmake/help/latest/command/find_package.html) command tells *cmake* to find a thread library on Linux, macOS, and Windows. Further down we add the found package to the libraries built into the project (see `${CMAKE_THREAD_LIBS_INIT}`):
-   ```cmake
-   find_package(Threads REQUIRED)
-   ```
-   This is required in order to use DroneCore!
-
-1. The [include_directories()](https://cmake.org/cmake/help/latest/command/include_directories.html) tells *cmake* where to find locally installed header files (if DroneCore is installed globally this is not required). 
-   ```cmake
-   include_directories(
-       # Not needed if installed system-wide
-       ${CMAKE_SOURCE_DIR}/../../install/include
-   )
-   ```
-
-   > **Note** `CMAKE_SOURCE_DIR` is the directory in which **CMakeLists.txt** is stored, and provides a useful way of defining relative paths to the header files. This example assumes that your application is nested two levels deep, in order to access the include files installed locally to: **/Dronecore/install/include**.
-1. The [add_executable()](https://cmake.org/cmake/help/latest/command/add_executable.html) command specifies the name for your generated executable and your source file(s). 
-   ```cmake
-   add_executable(your_executable_name
-       your_source_file.cpp
-   )
-  ```
-1. Here we define a variable for the location of the DroneCore library, depending on platform. As for the include files, this requires a relative path (to **DroneCore/install/lib/*). This is then used in the next step.
-   ```cmake
-   if(WINDOWS)
-       set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
-   else()
-       set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a")
-   endif()
-   ```
-1. The [target_link_libraries()](https://cmake.org/cmake/help/latest/command/target_link_libraries.html) command defines the libraries that your executable (`your_executable_name`) will link against. Here we use the `${dronecore_lib}` variable defined above. We comment out the `dronecore`, because the two definitions for libraries conflict.
-```cmake
-target_link_libraries(your_executable_name
-    ${dronecore_lib}
-    # If installed system-wide:
-    # dronecore
-    ${CMAKE_THREAD_LIBS_INIT}  # Link against thread library found using find_package() 
-    ${platform_libs}  # Variable containing all libraries that to link against for this platform (e.g. pthread).
+    # ... any other linked libraries
 )
 ```
 

--- a/en/guide/toolchain.md
+++ b/en/guide/toolchain.md
@@ -139,7 +139,7 @@ To create and run the app on Linux/macOS:
    ```
 
 To create and run the app on Windows:
-1. Open the *VS2015 x64 Native Tools Command Prompt*.
+1. Open the *VS2017 x64 Native Tools Command Prompt*.
 1. Navigate to the app source directory and enter the commands as shown below:
    ```bash 
    cd /path/to/your/application/   # Open a prompt and navigate to your application 

--- a/en/guide/toolchain.md
+++ b/en/guide/toolchain.md
@@ -118,7 +118,7 @@ target_link_libraries(your_executable_name
 
 This section assumes that you have already [built and installed the DroneCore C++ Library](../contributing/build.md) and that your example has a **CMakeLists.txt** in its root directory. 
 
-To create and run the app:
+To create and run the app on Linux/macOS:
 1. First create a build directory and run *cmake*: 
    ```bash 
    cd /path/to/your/application/   # Open a prompt and navigate to your application 
@@ -126,22 +126,26 @@ To create and run the app:
    cmake ..   # Create make files for your current platform
    ```
    > **Tip** Make files for release binaries are created by default. Use the flag `-DCMAKE_BUILD_TYPE=Debug` to build debug binaries:
-  ```
-  cmake -DCMAKE_BUILD_TYPE=Debug ..
-  ```
+   ```
+   cmake -DCMAKE_BUILD_TYPE=Debug ..
+   ```
 1. Build the project
-   * Linux/macOS:
-     ```bash 
-     make -j8
-     ``` 
-   * Windows:
-     ```bash 
-     cmake --build .
-     ``` 
+   ```bash 
+   make -j8
+   ```
 1. Execute the file (in your build directory):
-     ```bash 
-     ./your_executable_name  # Run your new executable
-     ```
+   ```bash 
+   ./your_executable_name  # Run your new executable
+   ```
+
+On Windows the commands are:
+```bash 
+cd /path/to/your/application/   # Open a prompt and navigate to your application 
+mkdir build && cd build   # Create a build directory and navigate into it
+cmake .. -G "Visual Studio 15 2017 Win64" # Create make files for your current platform
+cmake --build .  # Build the file 
+./your_executable_name  # Run your new executable
+```
 
 
 ## Useful Links

--- a/en/guide/toolchain.md
+++ b/en/guide/toolchain.md
@@ -131,21 +131,23 @@ To create and run the app on Linux/macOS:
    ```
 1. Build the project
    ```bash 
-   make -j8
+   make
    ```
 1. Execute the file (in your build directory):
    ```bash 
    ./your_executable_name  # Run your new executable
    ```
 
-On Windows the commands are:
-```bash 
-cd /path/to/your/application/   # Open a prompt and navigate to your application 
-mkdir build && cd build   # Create a build directory and navigate into it
-cmake .. -G "Visual Studio 15 2017 Win64" # Create make files for your current platform
-cmake --build .  # Build the file 
-./your_executable_name  # Run your new executable
-```
+To create and run the app on Windows:
+1. Open the *VS2015 x64 Native Tools Command Prompt*.
+1. Navigate to the app source directory and enter the commands as shown below:
+   ```bash 
+   cd /path/to/your/application/   # Open a prompt and navigate to your application 
+   mkdir build && cd build   # Create a build directory and navigate into it
+   cmake .. -G "Visual Studio 15 2017 Win64" # Create make files for your current platform
+   cmake --build .  # Build the file 
+   ./your_executable_name  # Run your new executable
+   ```
 
 
 ## Useful Links


### PR DESCRIPTION
This is first draft of doc updates for https://github.com/dronecore/DroneCore/pull/130 (as recorded in #51 ). More to come, there are open issues required to complete this.

- [x] Change Builds to reflect system wide install default
  - Examples require `sudo`: https://github.com/dronecore/DroneCore/issues/156
- [x] Update examples to include new CMakeLists
  - Examples not running: https://github.com/dronecore/DroneCore/issues/157
- [x] Update guide to explain how to create CMakeLists
   - [x] System wide
   - [x] Local
- [x] Test instructions Linux
  - [x] Test local build linux
  - [x] Test system build linux
  - [x] Test example vs system build on linux
  - [x] Test example vs local build on linux
  - [x] Test can build debug/release and update (system only)
- [ ] Test can build apiref and update
- [x] Remove requirement to link against pthread (now done inside dronecore)
- [x] Confirm all the other ios build etc stuff works.
   - Confirmed by @julianoes 
- [x] Confirm and document external library build. Do in both build doc and the extension doc.
- [ ] Windows
  - [x] Test build windows
  - [x] Test local install windows
     - [ ] Test example build against local install windows - https://github.com/dronecore/DroneCore/issues/162
  - [ ] Test system install windows [STILL NOT SUPPORTED?]
- [x] Examples - update output in docs
- [ ] Test `make docs` - Fail https://github.com/dronecore/DroneCore/issues/159