### PR TITLE
Update UDP client connection syntax to use udpin://

### DIFF
--- a/en/cpp/examples/README.md
+++ b/en/cpp/examples/README.md
@@ -79,16 +79,16 @@ cmake --build build -j4
 ### Running the Examples {#running_the_examples}
 
 You can then run the example, specifying the connection URL as the first argument.
-When running with the Simulator, you will use the connection string: `udpin://:14540`
+When running with the Simulator, you will use the connection string: `udpin://0.0.0.0:14540`
 
 On Linux/macOS you would run the following (from the **/build** directory):
 ```sh
-build/takeoff_and_land udpin://:14540
+build/takeoff_and_land udpin://0.0.0.0:14540
 ```
 
 For Windows you would run the following (from the **\build\Debug\** directory):
 ```cmd
-build\Debug\takeoff_and_land.exe udpin://:14540
+build\Debug\takeoff_and_land.exe udpin://0.0.0.0:14540
 ```
 
 > **Tip** Most examples will create a binary with the same name as the example.

--- a/en/cpp/examples/README.md
+++ b/en/cpp/examples/README.md
@@ -79,16 +79,16 @@ cmake --build build -j4
 ### Running the Examples {#running_the_examples}
 
 You can then run the example, specifying the connection URL as the first argument.
-When running with the Simulator, you will use the connection string: `udp://:14540`
+When running with the Simulator, you will use the connection string: `udpin://:14540`
 
 On Linux/macOS you would run the following (from the **/build** directory):
 ```sh
-build/takeoff_and_land udp://:14540
+build/takeoff_and_land udpin://:14540
 ```
 
 For Windows you would run the following (from the **\build\Debug\** directory):
 ```cmd
-build\Debug\takeoff_and_land.exe udp://:14540
+build\Debug\takeoff_and_land.exe udpin://:14540
 ```
 
 > **Tip** Most examples will create a binary with the same name as the example.

--- a/en/cpp/examples/fly_mission.md
+++ b/en/cpp/examples/fly_mission.md
@@ -15,7 +15,7 @@ The example terminal output should be similar to that shown below:
   A release build will omit the "Debug" messages.
 
 ```
-$ ./fly_mission udp://:14540
+$ ./fly_mission udpin://:14540
 ```
 ```
 Waiting to discover system...

--- a/en/cpp/examples/fly_mission.md
+++ b/en/cpp/examples/fly_mission.md
@@ -15,7 +15,7 @@ The example terminal output should be similar to that shown below:
   A release build will omit the "Debug" messages.
 
 ```
-$ ./fly_mission udpin://:14540
+$ ./fly_mission udpin://0.0.0.0:14540
 ```
 ```
 Waiting to discover system...

--- a/en/cpp/examples/follow_me.md
+++ b/en/cpp/examples/follow_me.md
@@ -29,7 +29,7 @@ The example terminal output should be similar to that shown below:
   A release build will omit the "Debug" messages.
 
 ```
-$ ./follow_me udpin://:14540
+$ ./follow_me udpin://0.0.0.0:14540
 ```
 ```
 [01:55:59|Info ] DronecodeSDK version: 0.2.8 (dronecode_sdk_impl.cpp:25)

--- a/en/cpp/examples/follow_me.md
+++ b/en/cpp/examples/follow_me.md
@@ -29,7 +29,7 @@ The example terminal output should be similar to that shown below:
   A release build will omit the "Debug" messages.
 
 ```
-$ ./follow_me udp://:14540
+$ ./follow_me udpin://:14540
 ```
 ```
 [01:55:59|Info ] DronecodeSDK version: 0.2.8 (dronecode_sdk_impl.cpp:25)

--- a/en/cpp/examples/offboard_velocity.md
+++ b/en/cpp/examples/offboard_velocity.md
@@ -15,7 +15,7 @@ The example terminal output should be similar to that shown below:
   A release build will omit the "Debug" messages.
 
 ```
-$ ./offboard udp://:14540
+$ ./offboard udpin://:14540
 ```
 ```
 Wait for system to connect via heartbeat

--- a/en/cpp/examples/offboard_velocity.md
+++ b/en/cpp/examples/offboard_velocity.md
@@ -15,7 +15,7 @@ The example terminal output should be similar to that shown below:
   A release build will omit the "Debug" messages.
 
 ```
-$ ./offboard udpin://:14540
+$ ./offboard udpin://0.0.0.0:14540
 ```
 ```
 Wait for system to connect via heartbeat

--- a/en/cpp/examples/takeoff_and_land.md
+++ b/en/cpp/examples/takeoff_and_land.md
@@ -18,7 +18,7 @@ The example terminal output should be similar to that shown below:
   A release build will omit the "Debug" messages.
 
 ```sh
-$ ./takeoff_and_land udp://:14540
+$ ./takeoff_and_land udpin://:14540
 ```
 ```sh
 Waiting to discover system...

--- a/en/cpp/examples/takeoff_and_land.md
+++ b/en/cpp/examples/takeoff_and_land.md
@@ -18,7 +18,7 @@ The example terminal output should be similar to that shown below:
   A release build will omit the "Debug" messages.
 
 ```sh
-$ ./takeoff_and_land udpin://:14540
+$ ./takeoff_and_land udpin://0.0.0.0:14540
 ```
 ```sh
 Waiting to discover system...

--- a/en/cpp/examples/transition_vtol_fixed_wing.md
+++ b/en/cpp/examples/transition_vtol_fixed_wing.md
@@ -16,7 +16,7 @@ Otherwise the example is built and run [in the standard way](../examples/README.
 The example terminal output for a debug build of the SDK should be similar to that shown below (a release build will omit the "Debug" messages):
 
 ```
-$ ./transition_vtol_fixed_wing udp://:14540
+$ ./transition_vtol_fixed_wing udpin://:14540
 ```
 ```
 Waiting to discover system...

--- a/en/cpp/examples/transition_vtol_fixed_wing.md
+++ b/en/cpp/examples/transition_vtol_fixed_wing.md
@@ -16,7 +16,7 @@ Otherwise the example is built and run [in the standard way](../examples/README.
 The example terminal output for a debug build of the SDK should be similar to that shown below (a release build will omit the "Debug" messages):
 
 ```
-$ ./transition_vtol_fixed_wing udpin://:14540
+$ ./transition_vtol_fixed_wing udpin://0.0.0.0:14540
 ```
 ```
 Waiting to discover system...

--- a/en/cpp/guide/connections.md
+++ b/en/cpp/guide/connections.md
@@ -58,14 +58,14 @@ The code snippet below shows how to set up a connection in server mode and liste
 
 ```cpp
 Mavsdk mavsdk;
-ConnectionResult connection_result = mavsdk.add_any_connection("udp://:14540");
+ConnectionResult connection_result = mavsdk.add_any_connection("udpin://:14540");
 if (connection_result != ConnectionResult::Success) {
     std::cout << "Adding connection failed: " << connection_result << '\n';
     return;
 }
 ```
 
-> **Note** The connection string used above (`udp://:14540`) is to the [standard PX4 UDP port](https://docs.px4.io/master/en/simulation/#default-px4-mavlink-udp-ports) for off-board APIs (14540).
+> **Note** The connection string used above (`udpin://:14540`) is to the [standard PX4 UDP port](https://docs.px4.io/master/en/simulation/#default-px4-mavlink-udp-ports) for off-board APIs (14540).
   This is the normal/most common way for offboard APIs to connect to PX4 over WiFi.
   The standard way to talk to a ground station (e.g. QGC is on port 14550).
 
@@ -169,7 +169,7 @@ To forward bi-directional from UDP to serial and serial to UDP, you would set bo
 
 ```cpp
 Mavsdk mavsdk;
-mavsdk.add_any_connection("udp://:14540", ForwardingOption::ForwardingOn);
+mavsdk.add_any_connection("udpin://:14540", ForwardingOption::ForwardingOn);
 mavsdk.add_any_connection("serial:///dev/serial/by-id/usb-FTDI_FT232R_USB_UART_XXXXXXXX-if00-port0:57600", ForwardingOption::ForwardingOn);
 ```
 
@@ -177,7 +177,7 @@ To forward only in one direction, e.g to send messages arriving on serial over U
 
 ```cpp
 Mavsdk mavsdk;
-mavsdk.add_any_connection("udp://:14540", ForwardingOption::ForwardingOn);
+mavsdk.add_any_connection("udpin://:14540", ForwardingOption::ForwardingOn);
 mavsdk.add_any_connection("serial:///dev/serial/by-id/usb-FTDI_FT232R_USB_UART_XXXXXXXX-if00-port0:57600", `ForwardingOption::ForwardingOff`);
 ```
 

--- a/en/cpp/guide/connections.md
+++ b/en/cpp/guide/connections.md
@@ -58,14 +58,14 @@ The code snippet below shows how to set up a connection in server mode and liste
 
 ```cpp
 Mavsdk mavsdk;
-ConnectionResult connection_result = mavsdk.add_any_connection("udpin://:14540");
+ConnectionResult connection_result = mavsdk.add_any_connection("udpin://0.0.0.0:14540");
 if (connection_result != ConnectionResult::Success) {
     std::cout << "Adding connection failed: " << connection_result << '\n';
     return;
 }
 ```
 
-> **Note** The connection string used above (`udpin://:14540`) is to the [standard PX4 UDP port](https://docs.px4.io/master/en/simulation/#default-px4-mavlink-udp-ports) for off-board APIs (14540).
+> **Note** The connection string used above (`udpin://0.0.0.0:14540`) is to the [standard PX4 UDP port](https://docs.px4.io/master/en/simulation/#default-px4-mavlink-udp-ports) for off-board APIs (14540).
   This is the normal/most common way for offboard APIs to connect to PX4 over WiFi.
   The standard way to talk to a ground station (e.g. QGC is on port 14550).
 
@@ -169,7 +169,7 @@ To forward bi-directional from UDP to serial and serial to UDP, you would set bo
 
 ```cpp
 Mavsdk mavsdk;
-mavsdk.add_any_connection("udpin://:14540", ForwardingOption::ForwardingOn);
+mavsdk.add_any_connection("udpin://0.0.0.0:14540", ForwardingOption::ForwardingOn);
 mavsdk.add_any_connection("serial:///dev/serial/by-id/usb-FTDI_FT232R_USB_UART_XXXXXXXX-if00-port0:57600", ForwardingOption::ForwardingOn);
 ```
 
@@ -177,7 +177,7 @@ To forward only in one direction, e.g to send messages arriving on serial over U
 
 ```cpp
 Mavsdk mavsdk;
-mavsdk.add_any_connection("udpin://:14540", ForwardingOption::ForwardingOn);
+mavsdk.add_any_connection("udpin://0.0.0.0:14540", ForwardingOption::ForwardingOn);
 mavsdk.add_any_connection("serial:///dev/serial/by-id/usb-FTDI_FT232R_USB_UART_XXXXXXXX-if00-port0:57600", `ForwardingOption::ForwardingOff`);
 ```
 

--- a/en/cpp/guide/general_usage.md
+++ b/en/cpp/guide/general_usage.md
@@ -75,7 +75,7 @@ Linux (e.g Raspberry Pi) connected to the vehicle via Serial port | `serial:///d
 Linux connected to the vehicle via USB | `serial:///dev/ttyUSBn`,  where `n` = the port | `serial:///dev/ttyUSB0`
 macOS connected to the vehicle via Serial port | `serial:///dev/tty.usbserial-n`,  where `n` = the USB device id | `serial:///dev/tty.usbserial-DA00AG57`
 macOS connected to the vehicle via USB | `serial:///dev/tty.usbmodem-n`,  where `n` = the USB device id | `serial:///dev/tty.usbmodem--DA00AG57`
-SITL connected to the vehicle via UDP | `udpin://:14540`
+SITL connected to the vehicle via UDP | `udpin://0.0.0.0:14540`
 
 
 ### Connection Status

--- a/en/cpp/guide/general_usage.md
+++ b/en/cpp/guide/general_usage.md
@@ -75,7 +75,7 @@ Linux (e.g Raspberry Pi) connected to the vehicle via Serial port | `serial:///d
 Linux connected to the vehicle via USB | `serial:///dev/ttyUSBn`,  where `n` = the port | `serial:///dev/ttyUSB0`
 macOS connected to the vehicle via Serial port | `serial:///dev/tty.usbserial-n`,  where `n` = the USB device id | `serial:///dev/tty.usbserial-DA00AG57`
 macOS connected to the vehicle via USB | `serial:///dev/tty.usbmodem-n`,  where `n` = the USB device id | `serial:///dev/tty.usbmodem--DA00AG57`
-SITL connected to the vehicle via UDP | `udp://:14540`
+SITL connected to the vehicle via UDP | `udpin://:14540`
 
 
 ### Connection Status

--- a/en/cpp/quickstart.md
+++ b/en/cpp/quickstart.md
@@ -83,13 +83,13 @@ First start PX4 in SITL (Simulation) and *QGroundControl* as described above.
 
 Then run the example app (from the **example/takeoff_land/build** directory) as shown:
 ```sh
-build/takeoff_and_land udp://:14540
+build/takeoff_and_land udpin://:14540
 ```
 
 The MAVSDK application should connect to PX4, and you will be able to observe the example running in the SDK terminal, SITL terminal, and/or *QGroundControl*.
 The expected behaviour is shown here: [Example: Takeoff and Land](examples/takeoff_and_land.md).
 
-> **Note** The first argument above is the connection string (`udp://:14540`).
+> **Note** The first argument above is the connection string (`udpin://:14540`).
   This is the standard PX4 UDP port for connecting to offboard APIs (also see [Connecting to Systems](guide/connections.md)).
 
 

--- a/en/cpp/quickstart.md
+++ b/en/cpp/quickstart.md
@@ -83,13 +83,13 @@ First start PX4 in SITL (Simulation) and *QGroundControl* as described above.
 
 Then run the example app (from the **example/takeoff_land/build** directory) as shown:
 ```sh
-build/takeoff_and_land udpin://:14540
+build/takeoff_and_land udpin://0.0.0.0:14540
 ```
 
 The MAVSDK application should connect to PX4, and you will be able to observe the example running in the SDK terminal, SITL terminal, and/or *QGroundControl*.
 The expected behaviour is shown here: [Example: Takeoff and Land](examples/takeoff_and_land.md).
 
-> **Note** The first argument above is the connection string (`udpin://:14540`).
+> **Note** The first argument above is the connection string (`udpin://0.0.0.0:14540`).
   This is the standard PX4 UDP port for connecting to offboard APIs (also see [Connecting to Systems](guide/connections.md)).
 
 


### PR DESCRIPTION
Changed all instances of the deprecated UDP connection syntax udp://:PORT to the recommended udpin://:PORT following the deprecation warning: Connection using udp:// is deprecated, please use udpin:// or udpout:// (cli_arg.cpp:28)